### PR TITLE
Add tooltips for joker description/rarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
     <div id="joker-tooltip" class="joker-tooltip">
         <div class="tooltip-title"></div>
         <div class="tooltip-description"></div>
+        <div class="tooltip-rarity"></div>
     </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -57,5 +57,11 @@
 
         </div>
     </div>
+
+    <!-- Tooltip container -->
+    <div id="joker-tooltip" class="joker-tooltip">
+        <div class="tooltip-title"></div>
+        <div class="tooltip-description"></div>
+    </div>
 </body>
 </html>

--- a/static/jokers.json
+++ b/static/jokers.json
@@ -1,1052 +1,1052 @@
 [
-  {
-    "name": "8 Ball",
-    "image": "8 Ball.webp",
-    "status": false,
-    "id": "j_8_ball",
-    "description": "<div class='joker-description'><span class='c-green'>1 in 4</span> chance for each<br>played <span class='c-attention'>8</span> to create a<br><span class='c-tarot'>Tarot</span> card when scored<br><span class='c-inactive'>(Must have room)</span></div>"
-  },
-  {
-    "name": "Abstract Joker",
-    "image": "Abstract Joker.webp",
-    "status": false,
-    "id": "j_abstract",
-    "description": "<div class='joker-description'><span class='c-mult'>+3</span> Mult for<br>each <span class='c-attention'>Joker</span> card<br><span class='c-inactive'>(Currently </span><span class='c-red'>+0</span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Acrobat",
-    "image": "Acrobat.webp",
-    "status": false,
-    "id": "j_acrobat",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3 </span> Mult on <span class='c-attention'>final</span><br><span class='c-attention'>hand</span> of round</div>"
-  },
-  {
-    "name": "Ancient Joker",
-    "image": "Ancient Joker.webp",
-    "status": false,
-    "id": "j_ancient",
-    "description": "<div class='joker-description'>Each played card with<br><span class='variable'>[random suit]</span> suit gives<br><span class='x-mult c-red c-white'> X1.5 </span> Mult when scored,<br><span class='size-0-8'>suit changes at end of round</span></div>"
-  },
-  {
-    "name": "Arrowhead",
-    "image": "Arrowhead.webp",
-    "status": false,
-    "id": "j_arrowhead",
-    "description": "<div class='joker-description'>Played cards with<br><span class='c-spades'>Spade</span> suit give<br><span class='c-chips'>+50</span> Chips when scored</div>"
-  },
-  {
-    "name": "Astronomer",
-    "image": "Astronomer.webp",
-    "status": false,
-    "id": "j_astronomer",
-    "description": "<div class='joker-description'>All <span class='c-planet'>Planet</span> cards and<br><span class='c-planet'>Celestial Packs</span> in<br>the shop are <span class='c-attention'>free</span></div>"
-  },
-  {
-    "name": "Banner",
-    "image": "Banner.webp",
-    "status": false,
-    "id": "j_banner",
-    "description": "<div class='joker-description'><span class='c-chips'>+30</span> Chips for<br>each remaining<br><span class='c-attention'>discard</span></div>"
-  },
-  {
-    "name": "Baron",
-    "image": "Baron.webp",
-    "status": false,
-    "id": "j_baron",
-    "description": "<div class='joker-description'>Each <span class='c-attention'>King</span><br>held in hand<br>gives <span class='x-mult c-red c-white'> X1.5 </span> Mult</div>"
-  },
-  {
-    "name": "Baseball Card",
-    "image": "Baseball Card.webp",
-    "status": false,
-    "id": "j_baseball",
-    "description": "<div class='joker-description'><span class='c-green'>Uncommon</span> Jokers<br>each give <span class='x-mult c-red c-white'> X1.5 </span> Mult</div>"
-  },
-  {
-    "name": "Blackboard",
-    "image": "Blackboard.webp",
-    "status": false,
-    "id": "j_blackboard",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3 </span> Mult if all<br>cards held in hand<br>are <span class='c-spades'>Spades</span> or <span class='c-clubs'>Clubs</span></div>"
-  },
-  {
-    "name": "Bloodstone",
-    "image": "Bloodstone.webp",
-    "status": false,
-    "id": "j_bloodstone",
-    "description": "<div class='joker-description'><span class='c-green'>1 in 2</span> chance for<br>played cards with<br><span class='c-hearts'>Heart</span> suit to give<br><span class='x-mult c-red c-white'> X1.5 </span> Mult when scored</div>"
-  },
-  {
-    "name": "Blue Joker",
-    "image": "Blue Joker.webp",
-    "status": false,
-    "id": "j_blue_joker",
-    "description": "<div class='joker-description'><span class='c-chips'>+2</span> Chips for each<br>remaining card in <span class='c-attention'>deck</span><br><span class='c-inactive'>(Currently </span><span class='c-chips'>+52</span><span class='c-inactive'> Chips)</span></div>"
-  },
-  {
-    "name": "Blueprint",
-    "image": "Blueprint.webp",
-    "status": false,
-    "id": "j_blueprint",
-    "description": "<div class='joker-description'>Copies ability of<br><span class='c-attention'>Joker</span> to the right</div>"
-  },
-  {
-    "name": "Bootstraps",
-    "image": "Bootstraps.webp",
-    "status": false,
-    "id": "j_bootstraps",
-    "description": "<div class='joker-description'><span class='c-mult'>+2</span> Mult for every<br><span class='c-money'>$5</span> you have<br><span class='c-inactive'>(Currently </span><span class='c-mult'>+0</span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Brainstorm",
-    "image": "Brainstorm.webp",
-    "status": false,
-    "id": "j_brainstorm",
-    "description": "<div class='joker-description'>Copies the ability<br>of leftmost <span class='c-attention'>Joker</span></div>"
-  },
-  {
-    "name": "Bull",
-    "image": "Bull.webp",
-    "status": false,
-    "id": "j_bull",
-    "description": "<div class='joker-description'><span class='c-chips'>+2</span> Chips for<br>each <span class='c-money'>$1</span> you have<br><span class='c-inactive'>(Currently </span><span class='c-chips'>+0</span><span class='c-inactive'> Chips)</span></div>"
-  },
-  {
-    "name": "Burglar",
-    "image": "Burglar.webp",
-    "status": false,
-    "id": "j_burglar",
-    "description": "<div class='joker-description'>When <span class='c-attention'>Blind</span> is selected,<br>gain <span class='c-blue'>+3</span> Hands and<br><span class='c-attention'>lose all discards</span></div>"
-  },
-  {
-    "name": "Burnt Joker",
-    "image": "Burnt Joker.webp",
-    "status": false,
-    "id": "j_burnt",
-    "description": "<div class='joker-description'>Upgrade the level of<br>the first <span class='c-attention'>discarded</span><br>poker hand each round</div>"
-  },
-  {
-    "name": "Business Card",
-    "image": "Business Card.webp",
-    "status": false,
-    "id": "j_business",
-    "description": "<div class='joker-description'>Played <span class='c-attention'>face</span> cards have<br>a <span class='c-green'>1 in 2</span> chance to<br>give <span class='c-money'>$2</span> when scored</div>"
-  },
-  {
-    "name": "Campfire",
-    "image": "Campfire.webp",
-    "status": false,
-    "id": "j_campfire",
-    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'>X0.25</span> Mult<br>for each card <span class='c-attention'>sold</span>, resets<br>when <span class='c-attention'>Boss Blind</span> is defeated<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Canio",
-    "image": "Canio.webp",
-    "status": false,
-    "id": "j_caino",
-    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X1 </span> Mult<br>when a <span class='c-attention'>face</span> card<br>is destroyed<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Card Sharp",
-    "image": "Card Sharp.webp",
-    "status": false,
-    "id": "j_card_sharp",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3.0 </span> Mult if played<br><span class='c-attention'>poker hand</span> has already<br>been played this round</div>"
-  },
-  {
-    "name": "Cartomancer",
-    "image": "Cartomancer.webp",
-    "status": false,
-    "id": "j_cartomancer",
-    "description": "<div class='joker-description'>Create a <span class='c-tarot'>Tarot</span> card<br>when <span class='c-attention'>Blind</span> is selected<br><span class='c-inactive'>(Must have room)</span></div>"
-  },
-  {
-    "name": "Castle",
-    "image": "Castle.webp",
-    "status": false,
-    "id": "j_castle",
-    "description": "<div class='joker-description'>This Joker gains <span class='c-chips'>+3</span> Chips<br>per discarded <span class='variable'>[random owned suit]</span> card,<br>suit changes every round<br><span class='c-inactive'>(Currently </span><span class='c-chips'>+0</span><span class='c-inactive'> Chips)</span></div>"
-  },
-  {
-    "name": "Cavendish",
-    "image": "Cavendish.webp",
-    "status": false,
-    "id": "j_cavendish",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3.0 </span> Mult<br><span class='c-green'>1 in 1000</span> chance this<br>card is destroyed<br>at end of round</div>"
-  },
-  {
-    "name": "Ceremonial Dagger",
-    "image": "Ceremonial Dagger.webp",
-    "status": false,
-    "id": "j_ceremonial",
-    "description": "<div class='joker-description'>When <span class='c-attention'>Blind</span> is selected,<br>destroy Joker to the right<br>and permanently add <span class='c-attention'>double</span><br>its sell value to this <span class='c-red'>Mult</span><br><span class='c-inactive'>(Currently </span><span class='c-mult'>+0</span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Certificate",
-    "image": "Certificate.webp",
-    "status": false,
-    "id": "j_certificate",
-    "description": "<div class='joker-description'>When round begins,<br>add a random <span class='c-attention'>playing</span><br><span class='c-attention'>card</span> with a random<br><span class='c-attention'>seal</span> to your hand</div>"
-  },
-  {
-    "name": "Chaos the Clown",
-    "image": "Chaos the Clown.webp",
-    "status": false,
-    "id": "j_chaos",
-    "description": "<div class='joker-description'><span class='c-attention'>1</span> free <span class='c-green'>Reroll</span><br>per shop</div>"
-  },
-  {
-    "name": "Chicot",
-    "image": "Chicot.webp",
-    "status": false,
-    "id": "j_chicot",
-    "description": "<div class='joker-description'>Disables effect of<br>every <span class='c-attention'>Boss Blind</span></div>"
-  },
-  {
-    "name": "Clever Joker",
-    "image": "Clever Joker.webp",
-    "status": false,
-    "id": "j_clever",
-    "description": "<div class='joker-description'><span class='c-chips'>+80</span> Chips if played<br>hand contains<br>a <span class='c-attention'>Two Pair</span></div>"
-  },
-  {
-    "name": "Cloud 9",
-    "image": "Cloud 9.webp",
-    "status": false,
-    "id": "j_cloud_9",
-    "description": "<div class='joker-description'>Earn <span class='c-money'>$1</span> for each<br><span class='c-attention'>9</span> in your <span class='c-attention'>full deck</span><br>at end of round<br><span class='c-inactive'>(Currently <span class='c-money'>$4</span></span><span class='c-inactive'>)</span></div>"
-  },
-  {
-    "name": "Constellation",
-    "image": "Constellation.webp",
-    "status": false,
-    "id": "j_constellation",
-    "description": "<div class='joker-description'>This Joker gains<br><span class='x-mult c-red c-white'> X0.1 </span> Mult every time<br>a <span class='c-planet'>Planet</span> card is used<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Crafty Joker",
-    "image": "Crafty Joker.webp",
-    "status": false,
-    "id": "j_crafty",
-    "description": "<div class='joker-description'><span class='c-chips'>+80</span> Chips if played<br>hand contains<br>a <span class='c-attention'>Flush</span></div>"
-  },
-  {
-    "name": "Crazy Joker",
-    "image": "Crazy Joker.webp",
-    "status": false,
-    "id": "j_crazy",
-    "description": "<div class='joker-description'><span class='c-red'>+12</span> Mult if played<br>hand contains<br>a <span class='c-attention'>Straight</span></div>"
-  },
-  {
-    "name": "Credit Card",
-    "image": "Credit Card.webp",
-    "status": false,
-    "id": "j_credit_card",
-    "description": "<div class='joker-description'>Go up to<br><span class='c-red'>-$20</span> in debt</div>"
-  },
-  {
-    "name": "Delayed Gratification",
-    "image": "Delayed Gratification.webp",
-    "status": false,
-    "id": "j_delayed_grat",
-    "description": "<div class='joker-description'>Earn <span class='c-money'>$2</span> per <span class='c-attention'>discard</span> if<br>no discards are used<br>by end of the round</div>"
-  },
-  {
-    "name": "Devious Joker",
-    "image": "Devious Joker.webp",
-    "status": false,
-    "id": "j_devious",
-    "description": "<div class='joker-description'><span class='c-chips'>+100</span> Chips if played<br>hand contains<br>a <span class='c-attention'>Straight</span></div>"
-  },
-  {
-    "name": "Diet Cola",
-    "image": "Diet Cola.webp",
-    "status": false,
-    "id": "j_diet_cola",
-    "description": "<div class='joker-description'>Sell this card to<br>create a free<br><span class='c-attention'>Double Tag</span></div>"
-  },
-  {
-    "name": "DNA",
-    "image": "DNA.webp",
-    "status": false,
-    "id": "j_dna",
-    "description": "<div class='joker-description'>If <span class='c-attention'>first hand</span> of round<br>has only <span class='c-attention'>1</span> card, add a<br>permanent copy to deck<br>and draw it to <span class='c-attention'>hand</span></div>"
-  },
-  {
-    "name": "Driver's License",
-    "image": "Driver's License.webp",
-    "status": false,
-    "id": "j_drivers_license",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X#1# </span> Mult if you have<br>at least <span class='c-attention'>16</span> Enhanced<br>cards in your full deck<br><span class='c-inactive'>(Currently </span><span class='c-attention'>#2#</span><span class='c-inactive'>)</span></div>"
-  },
-  {
-    "name": "Droll Joker",
-    "image": "Droll Joker.webp",
-    "status": false,
-    "id": "j_droll",
-    "description": "<div class='joker-description'><span class='c-red'>+10</span> Mult if played<br>hand contains<br>a <span class='c-attention'>Flush</span></div>"
-  },
-  {
-    "name": "Drunkard",
-    "image": "Drunkard.webp",
-    "status": false,
-    "id": "j_drunkard",
-    "description": "<div class='joker-description'><span class='c-red'>+1</span> discard<br>each round</div>"
-  },
-  {
-    "name": "Dusk",
-    "image": "Dusk.webp",
-    "status": false,
-    "id": "j_dusk",
-    "description": "<div class='joker-description'>Retrigger all played<br>cards in <span class='c-attention'>final</span><br><span class='c-attention'>hand</span> of round</div>"
-  },
-  {
-    "name": "Egg",
-    "image": "Egg.webp",
-    "status": false,
-    "id": "j_egg",
-    "description": "<div class='joker-description'>Gains <span class='c-money'>$3</span> of<br><span class='c-attention'>sell value</span> at<br>end of round</div>"
-  },
-  {
-    "name": "Erosion",
-    "image": "Erosion.webp",
-    "status": false,
-    "id": "j_erosion",
-    "description": "<div class='joker-description'><span class='c-red'>+4</span> Mult for each<br>card below <span class='c-attention'>52</span><br>in your full deck<br><span class='c-inactive'>(Currently </span><span class='c-red'>+0</span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Even Steven",
-    "image": "Even Steven.webp",
-    "status": false,
-    "id": "j_even_steven",
-    "description": "<div class='joker-description'>Played cards with<br><span class='c-attention'>even</span> rank give<br><span class='c-mult'>+4</span> Mult when scored<br><span class='c-inactive'>(10, 8, 6, 4, 2)</span></div>"
-  },
-  {
-    "name": "Faceless Joker",
-    "image": "Faceless Joker.webp",
-    "status": false,
-    "id": "j_faceless",
-    "description": "<div class='joker-description'>Earn <span class='c-money'>$5</span> if <span class='c-attention'>3</span> or<br>more <span class='c-attention'>face cards</span><br>are discarded<br>at the same time</div>"
-  },
-  {
-    "name": "Fibonacci",
-    "image": "Fibonacci.webp",
-    "status": false,
-    "id": "j_fibonacci",
-    "description": "<div class='joker-description'>Each played <span class='c-attention'>Ace</span>,<br><span class='c-attention'>2</span>, <span class='c-attention'>3</span>, <span class='c-attention'>5</span>, or <span class='c-attention'>8</span> gives<br><span class='c-mult'>+8</span> Mult when scored</div>"
-  },
-  {
-    "name": "Flash Card",
-    "image": "Flash Card.webp",
-    "status": false,
-    "id": "j_flash",
-    "description": "<div class='joker-description'>This Joker gains <span class='c-mult'>+2</span> Mult<br>per <span class='c-attention'>reroll</span> in the shop<br><span class='c-inactive'>(Currently </span><span class='c-mult'>+0</span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Flower Pot",
-    "image": "Flower Pot.webp",
-    "status": false,
-    "id": "j_flower_pot",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3 </span> Mult if poker<br>hand contains a<br><span class='c-diamonds'>Diamond</span> card, <span class='c-clubs'>Club</span> card,<br><span class='c-hearts'>Heart</span> card, and <span class='c-spades'>Spade</span> card</div>"
-  },
-  {
-    "name": "Fortune Teller",
-    "image": "Fortune Teller.webp",
-    "status": false,
-    "id": "j_fortune_teller",
-    "description": "<div class='joker-description'><span class='c-red'>+1</span> Mult per <span class='c-purple'>Tarot</span><br>card used this run<br><span class='c-inactive'>(Currently </span><span class='c-red'>+0</span><span class='c-inactive'>)</span></div>"
-  },
-  {
-    "name": "Four Fingers",
-    "image": "Four Fingers.webp",
-    "status": false,
-    "id": "j_four_fingers",
-    "description": "<div class='joker-description'>All <span class='c-attention'>Flushes</span> and<br><span class='c-attention'>Straights</span> can be<br>made with <span class='c-attention'>4</span> cards</div>"
-  },
-  {
-    "name": "Gift Card",
-    "image": "Gift Card.webp",
-    "status": false,
-    "id": "j_gift",
-    "description": "<div class='joker-description'>Add <span class='c-money'>$1</span> of <span class='c-attention'>sell value</span><br>to every <span class='c-attention'>Joker</span> and<br><span class='c-attention'>Consumable</span> card at<br>end of round</div>"
-  },
-  {
-    "name": "Glass Joker",
-    "image": "Glass Joker.webp",
-    "status": false,
-    "id": "j_glass",
-    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.75 </span> Mult<br>for every <span class='c-attention'>Glass Card</span><br>that is destroyed<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Gluttonous Joker",
-    "image": "Gluttonous Joker.webp",
-    "status": false,
-    "id": "j_gluttenous_joker",
-    "description": "<div class='joker-description'>Played cards with<br><span class='c-clubs'>Clubs</span> suit give<br><span class='c-mult'>+3</span> Mult when scored</div>"
-  },
-  {
-    "name": "Golden Joker",
-    "image": "Golden Joker.webp",
-    "status": false,
-    "id": "j_golden",
-    "description": "<div class='joker-description'>Earn <span class='c-money'>$4</span> at<br>end of round</div>"
-  },
-  {
-    "name": "Golden Ticket",
-    "image": "Golden Ticket.webp",
-    "status": false,
-    "id": "j_ticket",
-    "description": "<div class='joker-description'>Played <span class='c-attention'>Gold</span> cards<br>earn <span class='c-money'>$4</span> when scored</div>"
-  },
-  {
-    "name": "Greedy Joker",
-    "image": "Greedy Joker.webp",
-    "status": false,
-    "id": "j_greedy_joker",
-    "description": "<div class='joker-description'>Played cards with<br><span class='c-diamonds'>Diamonds</span> suit give<br><span class='c-mult'>+3</span> Mult when scored</div>"
-  },
-  {
-    "name": "Green Joker",
-    "image": "Green Joker.webp",
-    "status": false,
-    "id": "j_green_joker",
-    "description": "<div class='joker-description'><span class='c-mult'>+1</span> Mult per hand played<br><span class='c-mult'>-1</span> Mult per discard<br><span class='c-inactive'>(Currently </span><span class='c-mult'>+0</span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Gros Michel",
-    "image": "Gros Michel.webp",
-    "status": false,
-    "id": "j_gros_michel",
-    "description": "<div class='joker-description'><span class='c-mult'>+15</span> Mult<br><span class='c-green'>1 in 6</span> chance this<br>card is destroyed<br>at end of round</div>"
-  },
-  {
-    "name": "Hack",
-    "image": "Hack.webp",
-    "status": false,
-    "id": "j_hack",
-    "description": "<div class='joker-description'>Retrigger<br>each played<br><span class='c-attention'>2</span>, <span class='c-attention'>3</span>, <span class='c-attention'>4</span>, or <span class='c-attention'>5</span></div>"
-  },
-  {
-    "name": "Half Joker",
-    "image": "Half Joker.webp",
-    "status": false,
-    "id": "j_half",
-    "description": "<div class='joker-description'><span class='c-red'>+20</span> Mult if played<br>hand contains<br><span class='c-attention'>3</span> or fewer cards</div>"
-  },
-  {
-    "name": "Hallucination",
-    "image": "Hallucination.webp",
-    "status": false,
-    "id": "j_hallucination",
-    "description": "<div class='joker-description'><span class='c-green'>1 in 2</span> chance to create<br>a <span class='c-tarot'>Tarot</span> card when any<br><span class='c-attention'>Booster Pack</span> is opened<br><span class='c-inactive'>(Must have room)</span></div>"
-  },
-  {
-    "name": "Hanging Chad",
-    "image": "Hanging Chad.webp",
-    "status": false,
-    "id": "j_hanging_chad",
-    "description": "<div class='joker-description'>Retrigger <span class='c-attention'>first</span> played<br>card used in scoring<br><span class='c-attention'>2</span> additional times</div>"
-  },
-  {
-    "name": "Hiker",
-    "image": "Hiker.webp",
-    "status": false,
-    "id": "j_hiker",
-    "description": "<div class='joker-description'>Every played <span class='c-attention'>card</span><br>permanently gains<br><span class='c-chips'>+5</span> Chips when scored</div>"
-  },
-  {
-    "name": "Hit the Road",
-    "image": "Hit the Road.webp",
-    "status": false,
-    "id": "j_hit_the_road",
-    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.5 </span> Mult<br>for every <span class='c-attention'>Jack</span><br>discarded this round<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Hologram",
-    "image": "Hologram.webp",
-    "status": false,
-    "id": "j_hologram",
-    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.25 </span> Mult<br>every time a <span class='c-attention'>playing card</span><br>is added to your deck<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Ice Cream",
-    "image": "Ice Cream.webp",
-    "status": false,
-    "id": "j_ice_cream",
-    "description": "<div class='joker-description'><span class='c-chips'>+100</span> Chips<br><span class='c-chips'>-5</span> Chips for<br>every hand played</div>"
-  },
-  {
-    "name": "Invisible Joker",
-    "image": "Invisible Joker.webp",
-    "status": false,
-    "id": "j_invisible",
-    "description": "<div class='joker-description'>After <span class='c-attention'>2</span> rounds,<br>sell this card to<br><span class='c-attention'>Duplicate</span> a random Joker<br><span class='c-inactive'>(Currently </span><span class='c-attention'>0</span><span class='c-inactive'>/2)</span></div>"
-  },
-  {
-    "name": "Joker",
-    "image": "Joker.webp",
-    "status": false,
-    "id": "j_joker",
-    "description": "<div class='joker-description'><span class='c-red'>+4</span> Mult</div>"
-  },
-  {
-    "name": "Joker Stencil",
-    "image": "Joker Stencil.webp",
-    "status": false,
-    "id": "j_stencil",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X1 </span> Mult for each<br>empty <span class='c-attention'>Joker</span> slot<br><span class='size-0-8'>Joker Stencil included</span><br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'>)</span></div>"
-  },
-  {
-    "name": "Jolly Joker",
-    "image": "Jolly Joker.webp",
-    "status": false,
-    "id": "j_jolly",
-    "description": "<div class='joker-description'><span class='c-red'>+8</span> Mult if played<br>hand contains<br>a <span class='c-attention'>Pair</span></div>"
-  },
-  {
-    "name": "Juggler",
-    "image": "Juggler.webp",
-    "status": false,
-    "id": "j_juggler",
-    "description": "<div class='joker-description'><span class='c-attention'>+1</span> hand size</div>"
-  },
-  {
-    "name": "Loyalty Card",
-    "image": "Loyalty Card.webp",
-    "status": false,
-    "id": "j_loyalty_card",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X4.0 </span> Mult every<br><span class='c-attention'>6</span> hands played<br><span class='c-inactive'></span></div>"
-  },
-  {
-    "name": "Luchador",
-    "image": "Luchador.webp",
-    "status": false,
-    "id": "j_luchador",
-    "description": "<div class='joker-description'>Sell this card to<br>disable the current<br><span class='c-attention'>Boss Blind</span></div>"
-  },
-  {
-    "name": "Lucky Cat",
-    "image": "Lucky Cat.webp",
-    "status": false,
-    "id": "j_lucky_cat",
-    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.25 </span> Mult<br>every time a <span class='c-attention'>Lucky</span> card<br><span class='c-green'>successfully</span> triggers<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Lusty Joker",
-    "image": "Lusty Joker.webp",
-    "status": false,
-    "id": "j_lusty_joker",
-    "description": "<div class='joker-description'>Played cards with<br><span class='c-hearts'>Hearts</span> suit give<br><span class='c-mult'>+3</span> Mult when scored</div>"
-  },
-  {
-    "name": "Mad Joker",
-    "image": "Mad Joker.webp",
-    "status": false,
-    "id": "j_mad",
-    "description": "<div class='joker-description'><span class='c-red'>+10</span> Mult if played<br>hand contains<br>a <span class='c-attention'>Two Pair</span></div>"
-  },
-  {
-    "name": "Madness",
-    "image": "Madness.webp",
-    "status": false,
-    "id": "j_madness",
-    "description": "<div class='joker-description'>When <span class='c-attention'>Small Blind</span> or <span class='c-attention'>Big Blind</span><br>is selected, gain <span class='x-mult c-red c-white'> X0.5 </span> Mult<br>and <span class='c-attention'>destroy</span> a random Joker<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Mail-In Rebate",
-    "image": "Mail-In Rebate.webp",
-    "status": false,
-    "id": "j_mail",
-    "description": "<div class='joker-description'>Earn <span class='c-money'>$5</span> for each<br>discarded <span class='c-attention'>2</span>, rank<br>changes every round</div>"
-  },
-  {
-    "name": "Marble Joker",
-    "image": "Marble Joker.webp",
-    "status": false,
-    "id": "j_marble",
-    "description": "<div class='joker-description'>Adds one <span class='c-attention'>Stone</span> card<br>to deck when<br><span class='c-attention'>Blind</span> is selected</div>"
-  },
-  {
-    "name": "Matador",
-    "image": "Matador.webp",
-    "status": false,
-    "id": "j_matador",
-    "description": "<div class='joker-description'>Earn <span class='c-money'>$8</span> if played<br>hand triggers the<br><span class='c-attention'>Boss Blind</span> ability</div>"
-  },
-  {
-    "name": "Merry Andy",
-    "image": "Merry Andy.webp",
-    "status": false,
-    "id": "j_merry_andy",
-    "description": "<div class='joker-description'><span class='c-red'>+3</span> discards<br>each round,<br><span class='c-red'>-1</span> hand size</div>"
-  },
-  {
-    "name": "Midas Mask",
-    "image": "Midas Mask.webp",
-    "status": false,
-    "id": "j_midas_mask",
-    "description": "<div class='joker-description'>All played <span class='c-attention'>face</span> cards<br>become <span class='c-attention'>Gold</span> cards<br>when scored</div>"
-  },
-  {
-    "name": "Mime",
-    "image": "Mime.webp",
-    "status": false,
-    "id": "j_mime",
-    "description": "<div class='joker-description'>Retrigger all<br>card <span class='c-attention'>held in</span><br><span class='c-attention'>hand</span> abilities</div>"
-  },
-  {
-    "name": "Misprint",
-    "image": "Misprint.webp",
-    "status": false,
-    "id": "j_misprint",
-    "description": "<div class='joker-description'><span class='c-mult'>+[0 to 23]</span> Mult</div>"
-  },
-  {
-    "name": "Mr. Bones",
-    "image": "Mr. Bones.webp",
-    "status": false,
-    "id": "j_mr_bones",
-    "description": "<div class='joker-description'>Prevents Death<br>if chips scored<br>are at least <span class='c-attention'>25%</span><br>of required chips<br><span class='size-1-1 c-red enhanced-text'>self destructs</span></div>"
-  },
-  {
-    "name": "Mystic Summit",
-    "image": "Mystic Summit.webp",
-    "status": false,
-    "id": "j_mystic_summit",
-    "description": "<div class='joker-description'><span class='c-mult'>+15</span> Mult when<br><span class='c-attention'>0</span> discards<br>remaining</div>"
-  },
-  {
-    "name": "Obelisk",
-    "image": "Obelisk.webp",
-    "status": false,
-    "id": "j_obelisk",
-    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.2 </span> Mult<br>per <span class='c-attention'>consecutive</span> hand played<br>without playing your<br>most played <span class='c-attention'>poker hand</span><br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Odd Todd",
-    "image": "Odd Todd.webp",
-    "status": false,
-    "id": "j_odd_todd",
-    "description": "<div class='joker-description'>Played cards with<br><span class='c-attention'>odd</span> rank give<br><span class='c-chips'>+31</span> Chips when scored<br><span class='c-inactive'>(A, 9, 7, 5, 3)</span></div>"
-  },
-  {
-    "name": "Onyx Agate",
-    "image": "Onyx Agate.webp",
-    "status": false,
-    "id": "j_onyx_agate",
-    "description": "<div class='joker-description'>Played cards with<br><span class='c-clubs'>Club</span> suit give<br><span class='c-mult'>+7</span> Mult when scored</div>"
-  },
-  {
-    "name": "Oops! All 6s",
-    "image": "Oops! All 6s.webp",
-    "status": false,
-    "id": "j_oops",
-    "description": "<div class='joker-description'>Doubles all <span class='c-attention'>listed</span><br><span class='c-green c-e:1 c-s:1.1'>probabilities</span><br><span class='c-inactive'>(ex: </span><span class='c-green'>1 in 3</span><span class='c-inactive'> -> </span><span class='c-green'>2 in 3</span><span class='c-inactive'>)</span></div>"
-  },
-  {
-    "name": "Pareidolia",
-    "image": "Pareidolia.webp",
-    "status": false,
-    "id": "j_pareidolia",
-    "description": "<div class='joker-description'>All cards are<br>considered<br><span class='c-attention'>face</span> cards</div>"
-  },
-  {
-    "name": "Perkeo",
-    "image": "Perkeo.webp",
-    "status": false,
-    "id": "j_perkeo",
-    "description": "<div class='joker-description'>Creates a <span class='c-dark-edition'>Negative</span> copy of<br><span class='c-attention'>1</span> random <span class='c-attention'>consumable</span><br>card in your possession<br>at the end of the <span class='c-attention'>shop</span></div>"
-  },
-  {
-    "name": "Photograph",
-    "image": "Photograph.webp",
-    "status": false,
-    "id": "j_photograph",
-    "description": "<div class='joker-description'>First played <span class='c-attention'>face</span><br>card gives <span class='x-mult c-red c-white'> X2 </span> Mult<br>when scored</div>"
-  },
-  {
-    "name": "Popcorn",
-    "image": "Popcorn.webp",
-    "status": false,
-    "id": "j_popcorn",
-    "description": "<div class='joker-description'><span class='c-mult'>+20</span> Mult<br><span class='c-mult'>-4</span> Mult per<br>round played</div>"
-  },
-  {
-    "name": "Raised Fist",
-    "image": "Raised Fist.webp",
-    "status": false,
-    "id": "j_raised_fist",
-    "description": "<div class='joker-description'>Adds <span class='c-attention'>double</span> the rank<br>of <span class='c-attention'>lowest</span> ranked card<br>held in hand to Mult</div>"
-  },
-  {
-    "name": "Ramen",
-    "image": "Ramen.webp",
-    "status": false,
-    "id": "j_ramen",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X2 </span> Mult,<br>loses <span class='x-mult c-red c-white'> X0.01 </span> Mult<br>per <span class='c-attention'>card</span> discarded</div>"
-  },
-  {
-    "name": "Red Card",
-    "image": "Red Card.webp",
-    "status": false,
-    "id": "j_red_card",
-    "description": "<div class='joker-description'>This Joker gains<br><span class='c-red'>+3</span> Mult when any<br><span class='c-attention'>Booster Pack</span> is skipped<br><span class='c-inactive'>(Currently </span><span class='c-red'>+0</span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Reserved Parking",
-    "image": "Reserved Parking.webp",
-    "status": false,
-    "id": "j_reserved_parking",
-    "description": "<div class='joker-description'>Each <span class='c-attention'>face</span> card<br>held in hand has<br>a <span class='c-green'>1 in 2</span> chance<br>to give <span class='c-money'>$1</span></div>"
-  },
-  {
-    "name": "Ride the Bus",
-    "image": "Ride the Bus.webp",
-    "status": false,
-    "id": "j_ride_the_bus",
-    "description": "<div class='joker-description'>This Joker gains <span class='c-mult'>+1</span> Mult<br>per <span class='c-attention'>consecutive</span> hand<br>played without a<br>scoring <span class='c-attention'>face</span> card<br><span class='c-inactive'>(Currently </span><span class='c-mult'>+0</span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Riff-Raff",
-    "image": "Riff-Raff.webp",
-    "status": false,
-    "id": "j_riff_raff",
-    "description": "<div class='joker-description'>When <span class='c-attention'>Blind</span> is selected,<br>create <span class='c-attention'>2 </span><span class='c-blue'>Common</span><span class='c-attention'> Jokers</span><br><span class='c-inactive'>(Must have room)</span></div>"
-  },
-  {
-    "name": "Rocket",
-    "image": "Rocket.webp",
-    "status": false,
-    "id": "j_rocket",
-    "description": "<div class='joker-description'>Earn <span class='c-money'>$1</span> at end of round<br>Payout increases by <span class='c-money'>$2</span><br>when <span class='c-attention'>Boss Blind</span> is defeated</div>"
-  },
-  {
-    "name": "Rough Gem",
-    "image": "Rough Gem.webp",
-    "status": false,
-    "id": "j_rough_gem",
-    "description": "<div class='joker-description'>Played cards with<br><span class='c-diamonds'>Diamond</span> suit earn<br><span class='c-money'>$1</span> when scored</div>"
-  },
-  {
-    "name": "Runner",
-    "image": "Runner.webp",
-    "status": false,
-    "id": "j_runner",
-    "description": "<div class='joker-description'>Gains <span class='c-chips'>+15</span> Chips<br>if played hand<br>contains a <span class='c-attention'>Straight</span><br><span class='c-inactive'>(Currently </span><span class='c-chips'>+0</span><span class='c-inactive'> Chips)</span></div>"
-  },
-  {
-    "name": "Satellite",
-    "image": "Satellite.webp",
-    "status": false,
-    "id": "j_satellite",
-    "description": "<div class='joker-description'>Earn <span class='c-money'>$1</span> at end of<br>round per unique <span class='c-planet'>Planet</span><br>card used this run<br><span class='c-inactive'>(Currently </span><span class='c-money'>$0</span><span class='c-inactive'>)</span></div>"
-  },
-  {
-    "name": "Scary Face",
-    "image": "Scary Face.webp",
-    "status": false,
-    "id": "j_scary_face",
-    "description": "<div class='joker-description'>Played <span class='c-attention'>face</span> cards<br>give <span class='c-chips'>+30</span> Chips<br>when scored</div>"
-  },
-  {
-    "name": "Scholar",
-    "image": "Scholar.webp",
-    "status": false,
-    "id": "j_scholar",
-    "description": "<div class='joker-description'>Played <span class='c-attention'>Aces</span><br>give <span class='c-chips'>+20</span> Chips<br>and <span class='c-mult'>+4</span> Mult<br>when scored</div>"
-  },
-  {
-    "name": "S\u00e9ance",
-    "image": "S\u00e9ance.webp",
-    "status": false,
-    "id": "j_seance",
-    "description": "<div class='joker-description'>If <span class='c-attention'>poker hand</span> is a<br><span class='c-attention'>Straight Flush</span>, create a<br>random <span class='c-spectral'>Spectral</span> card<br><span class='c-inactive'>(Must have room)</span></div>"
-  },
-  {
-    "name": "Seeing Double",
-    "image": "Seeing Double.webp",
-    "status": false,
-    "id": "j_seeing_double",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X2 </span> Mult if played<br>hand has a scoring<br><span class='c-clubs'>Club</span> card and a scoring<br>card of any other <span class='c-attention'>suit</span></div>"
-  },
-  {
-    "name": "Seltzer",
-    "image": "Seltzer.webp",
-    "status": false,
-    "id": "j_selzer",
-    "description": "<div class='joker-description'>Retrigger all<br>cards played for<br>the next <span class='c-attention'>10</span> hands</div>"
-  },
-  {
-    "name": "Shoot the Moon",
-    "image": "Shoot the Moon.webp",
-    "status": false,
-    "id": "j_shoot_the_moon",
-    "description": "<div class='joker-description'>Each <span class='c-attention'>Queen</span><br>held in hand<br>gives <span class='c-mult'>+13</span> Mult</div>"
-  },
-  {
-    "name": "Shortcut",
-    "image": "Shortcut.webp",
-    "status": false,
-    "id": "j_shortcut",
-    "description": "<div class='joker-description'>Allows <span class='c-attention'>Straights</span> to be<br>made with gaps of <span class='c-attention'>1 rank</span><br><span class='c-inactive'>(ex: </span><span class='c-attention'>10 8 6 5 3</span><span class='c-inactive'>)</span></div>"
-  },
-  {
-    "name": "Showman",
-    "image": "Showman.webp",
-    "status": false,
-    "id": "j_ring_master",
-    "description": "<div class='joker-description'><span class='c-attention'>Joker</span>, <span class='c-tarot'>Tarot</span>, <span class='c-planet'>Planet</span>,<br>and <span class='c-spectral'>Spectral</span> cards may<br>appear multiple times</div>"
-  },
-  {
-    "name": "Sixth Sense",
-    "image": "Sixth Sense.webp",
-    "status": false,
-    "id": "j_sixth_sense",
-    "description": "<div class='joker-description'>If <span class='c-attention'>first hand</span> of round is<br>a single <span class='c-attention'>6</span>, destroy it and<br>create a <span class='c-spectral'>Spectral</span> card<br><span class='c-inactive'>(Must have room)</span></div>"
-  },
-  {
-    "name": "Sly Joker",
-    "image": "Sly Joker.webp",
-    "status": false,
-    "id": "j_sly",
-    "description": "<div class='joker-description'><span class='c-chips'>+50</span> Chips if played<br>hand contains<br>a <span class='c-attention'>Pair</span></div>"
-  },
-  {
-    "name": "Smeared Joker",
-    "image": "Smeared Joker.webp",
-    "status": false,
-    "id": "j_smeared",
-    "description": "<div class='joker-description'><span class='c-hearts'>Hearts</span> and <span class='c-diamonds'>Diamonds</span><br>count as the same suit,<br><span class='c-spades'>Spades</span> and <span class='c-clubs'>Clubs</span><br>count as the same suit</div>"
-  },
-  {
-    "name": "Smiley Face",
-    "image": "Smiley Face.webp",
-    "status": false,
-    "id": "j_smiley",
-    "description": "<div class='joker-description'>Played <span class='c-attention'>face</span> cards<br>give <span class='c-mult'>+5</span> Mult<br>when scored</div>"
-  },
-  {
-    "name": "Sock and Buskin",
-    "image": "Sock and Buskin.webp",
-    "status": false,
-    "id": "j_sock_and_buskin",
-    "description": "<div class='joker-description'>Retrigger all<br>played <span class='c-attention'>face</span> cards</div>"
-  },
-  {
-    "name": "Space Joker",
-    "image": "Space Joker.webp",
-    "status": false,
-    "id": "j_space",
-    "description": "<div class='joker-description'><span class='c-green'>1 in 4</span> chance to<br>upgrade level of<br>played <span class='c-attention'>poker hand</span></div>"
-  },
-  {
-    "name": "Spare Trousers",
-    "image": "Spare Trousers.webp",
-    "status": false,
-    "id": "j_trousers",
-    "description": "<div class='joker-description'>This Joker gains <span class='c-mult'>+2</span> Mult<br>if played hand contains<br>a <span class='c-attention'>Two Pair</span><br><span class='c-inactive'>(Currently </span><span class='c-red'>+0</span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Splash",
-    "image": "Splash.webp",
-    "status": false,
-    "id": "j_splash",
-    "description": "<div class='joker-description'>Every <span class='c-attention'>played card</span><br>counts in scoring</div>"
-  },
-  {
-    "name": "Square Joker",
-    "image": "Square Joker.webp",
-    "status": false,
-    "id": "j_square",
-    "description": "<div class='joker-description'>This Joker gains <span class='c-chips'>+4</span> Chips<br>if played hand has<br>exactly <span class='c-attention'>4</span> cards<br><span class='c-inactive'>(Currently </span><span class='c-chips'>0</span><span class='c-inactive'> Chips)</span></div>"
-  },
-  {
-    "name": "Steel Joker",
-    "image": "Steel Joker.webp",
-    "status": false,
-    "id": "j_steel_joker",
-    "description": "<div class='joker-description'>Gives <span class='x-mult c-red c-white'> X0.2 </span> Mult<br>for each <span class='c-attention'>Steel Card</span><br>in your <span class='c-attention'>full deck</span><br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Stone Joker",
-    "image": "Stone Joker.webp",
-    "status": false,
-    "id": "j_stone",
-    "description": "<div class='joker-description'>Gives <span class='c-chips'>+25</span> Chips for<br>each <span class='c-attention'>Stone Card</span><br>in your <span class='c-attention'>full deck</span><br><span class='c-inactive'>(Currently </span><span class='c-chips'>+0</span><span class='c-inactive'> Chips)</span></div>"
-  },
-  {
-    "name": "Stuntman",
-    "image": "Stuntman.webp",
-    "status": false,
-    "id": "j_stuntman",
-    "description": "<div class='joker-description'><span class='c-chips'>+250</span> Chips,<br><span class='c-attention'>-2</span> hand size</div>"
-  },
-  {
-    "name": "Supernova",
-    "image": "Supernova.webp",
-    "status": false,
-    "id": "j_supernova",
-    "description": "<div class='joker-description'>Adds the number of times<br><span class='c-attention'>poker hand</span> has been<br>played this run to Mult</div>"
-  },
-  {
-    "name": "Superposition",
-    "image": "Superposition.webp",
-    "status": false,
-    "id": "j_superposition",
-    "description": "<div class='joker-description'>Create a <span class='c-tarot'>Tarot</span> card if<br>poker hand contains an<br><span class='c-attention'>Ace</span> and a <span class='c-attention'>Straight</span><br><span class='c-inactive'>(Must have room)</span></div>"
-  },
-  {
-    "name": "Swashbuckler",
-    "image": "Swashbuckler.webp",
-    "status": false,
-    "id": "j_swashbuckler",
-    "description": "<div class='joker-description'>Adds the sell value<br>of all other owned<br><span class='c-attention'>Jokers</span> to Mult<br><span class='c-inactive'>(Currently </span><span class='c-mult'>+1</span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "The Duo",
-    "image": "The Duo.webp",
-    "status": false,
-    "id": "j_duo",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X2 </span> Mult if played<br>hand contains<br>a <span class='c-attention'>Pair</span></div>"
-  },
-  {
-    "name": "The Family",
-    "image": "The Family.webp",
-    "status": false,
-    "id": "j_family",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X4 </span> Mult if played<br>hand contains<br>a <span class='c-attention'>Four of a Kind</span></div>"
-  },
-  {
-    "name": "The Idol",
-    "image": "The Idol.webp",
-    "status": false,
-    "id": "j_idol",
-    "description": "<div class='joker-description'>Each played <span class='c-attention'>[random owned card rank]</span><br>of <span class='variable'>[random owned card suit]</span> gives<br><span class='x-mult c-red c-white'> X2 </span> Mult when scored<br><span class='size-0-8'>Card changes every round</span></div>"
-  },
-  {
-    "name": "The Order",
-    "image": "The Order.webp",
-    "status": false,
-    "id": "j_order",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3 </span> Mult if played<br>hand contains<br>a <span class='c-attention'>Straight</span></div>"
-  },
-  {
-    "name": "The Tribe",
-    "image": "The Tribe.webp",
-    "status": false,
-    "id": "j_tribe",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X2 </span> Mult if played<br>hand contains<br>a <span class='c-attention'>Flush</span></div>"
-  },
-  {
-    "name": "The Trio",
-    "image": "The Trio.webp",
-    "status": false,
-    "id": "j_trio",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3 </span> Mult if played<br>hand contains<br>a <span class='c-attention'>Three of a Kind</span></div>"
-  },
-  {
-    "name": "Throwback",
-    "image": "Throwback.webp",
-    "status": false,
-    "id": "j_throwback",
-    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X0.25 </span> Mult for each<br><span class='c-attention'>Blind</span> skipped this run<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "To Do List",
-    "image": "To Do List.webp",
-    "status": false,
-    "id": "j_todo_list",
-    "description": "<div class='joker-description'>Earn <span class='c-money'>$4</span> if <span class='c-attention'>poker hand</span><br>is a <span class='c-attention'>High Card</span>,<br>poker hand changes<br>at end of round</div>"
-  },
-  {
-    "name": "To the Moon",
-    "image": "To the Moon.webp",
-    "status": false,
-    "id": "j_to_the_moon",
-    "description": "<div class='joker-description'>Earn an extra <span class='c-money'>$1</span> of<br><span class='c-attention'>interest</span> for every <span class='c-money'>$5</span> you<br>have at end of round</div>"
-  },
-  {
-    "name": "Trading Card",
-    "image": "Trading Card.webp",
-    "status": false,
-    "id": "j_trading",
-    "description": "<div class='joker-description'>If <span class='c-attention'>first discard</span> of round<br>has only <span class='c-attention'>1</span> card, destroy<br>it and earn <span class='c-money'>$3</span></div>"
-  },
-  {
-    "name": "Triboulet",
-    "image": "Triboulet.webp",
-    "status": false,
-    "id": "j_triboulet",
-    "description": "<div class='joker-description'>Played <span class='c-attention'>Kings</span> and<br><span class='c-attention'>Queens</span> each give<br><span class='x-mult c-red c-white'> X2 </span> Mult when scored</div>"
-  },
-  {
-    "name": "Troubadour",
-    "image": "Troubadour.webp",
-    "status": false,
-    "id": "j_troubadour",
-    "description": "<div class='joker-description'><span class='c-attention'>+2</span> hand size,<br><span class='c-blue'>-1</span> hand each round</div>"
-  },
-  {
-    "name": "Turtle Bean",
-    "image": "Turtle Bean.webp",
-    "status": false,
-    "id": "j_turtle_bean",
-    "description": "<div class='joker-description'><span class='c-attention'>+5</span> hand size,<br>reduces by<br><span class='c-red'>1</span> every round</div>"
-  },
-  {
-    "name": "Vagabond",
-    "image": "Vagabond.webp",
-    "status": false,
-    "id": "j_vagabond",
-    "description": "<div class='joker-description'>Create a <span class='c-purple'>Tarot</span> card<br>if hand is played<br>with <span class='c-money'>$4</span> or less</div>"
-  },
-  {
-    "name": "Vampire",
-    "image": "Vampire.webp",
-    "status": false,
-    "id": "j_vampire",
-    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.1 </span> Mult<br>per scoring <span class='c-attention'>Enhanced card</span> played,<br>removes card <span class='c-attention'>Enhancement</span><br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Walkie Talkie",
-    "image": "Walkie Talkie.webp",
-    "status": false,
-    "id": "j_walkie_talkie",
-    "description": "<div class='joker-description'>Each played <span class='c-attention'>10</span> or <span class='c-attention'>4</span><br>gives <span class='c-chips'>+10</span> Chips and<br><span class='c-mult'>+4</span> Mult when scored</div>"
-  },
-  {
-    "name": "Wee Joker",
-    "image": "Wee Joker.webp",
-    "status": false,
-    "id": "j_wee",
-    "description": "<div class='joker-description'>This Joker gains<br><span class='c-chips'>+8</span> Chips when each<br>played <span class='c-attention'>2</span> is scored<br><span class='c-inactive'>(Currently </span><span class='c-chips'>+0</span><span class='c-inactive'> Chips)</span></div>"
-  },
-  {
-    "name": "Wily Joker",
-    "image": "Wily Joker.webp",
-    "status": false,
-    "id": "j_wily",
-    "description": "<div class='joker-description'><span class='c-chips'>+100</span> Chips if played<br>hand contains<br>a <span class='c-attention'>Three of a Kind</span></div>"
-  },
-  {
-    "name": "Wrathful Joker",
-    "image": "Wrathful Joker.webp",
-    "status": false,
-    "id": "j_wrathful_joker",
-    "description": "<div class='joker-description'>Played cards with<br><span class='c-spades'>Spades</span> suit give<br><span class='c-mult'>+3</span> Mult when scored</div>"
-  },
-  {
-    "name": "Yorick",
-    "image": "Yorick.webp",
-    "status": false,
-    "id": "j_yorick",
-    "description": "<div class='joker-description'>This Joker gains<br><span class='x-mult c-red c-white'> X1 </span> Mult every <span class='c-attention'>23<span class='c-inactive'> [23]</span></span><br>cards discarded<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
-  },
-  {
-    "name": "Zany Joker",
-    "image": "Zany Joker.webp",
-    "status": false,
-    "id": "j_zany",
-    "description": "<div class='joker-description'><span class='c-red'>+12</span> Mult if played<br>hand contains<br>a <span class='c-attention'>Three of a Kind</span></div>"
-  }
+    {
+        "name": "8 Ball",
+        "image": "8 Ball.webp",
+        "status": false,
+        "id": "j_8_ball",
+        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 4</span> chance for each<br>played <span class=\"c-attention\">8</span> to create a<br><span class=\"c-tarot\">Tarot</span> card when scored<br><span class=\"c-inactive\">(Must have room)</span></div>"
+    },
+    {
+        "name": "Abstract Joker",
+        "image": "Abstract Joker.webp",
+        "status": false,
+        "id": "j_abstract",
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+3</span> Mult for<br>each <span class=\"c-attention\">Joker</span> card<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Acrobat",
+        "image": "Acrobat.webp",
+        "status": false,
+        "id": "j_acrobat",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult on <span class=\"c-attention\">final</span><br><span class=\"c-attention\">hand</span> of round</div>"
+    },
+    {
+        "name": "Ancient Joker",
+        "image": "Ancient Joker.webp",
+        "status": false,
+        "id": "j_ancient",
+        "description": "<div class=\"joker-description\">Each played card with<br><span class=\"variable\">Hearts</span> suit gives<br><span class=\"x-mult c-red c-white\"> X1.5 </span> Mult when scored,<br><span class=\"size-0-8\">suit changes at end of round</span></div>"
+    },
+    {
+        "name": "Arrowhead",
+        "image": "Arrowhead.webp",
+        "status": false,
+        "id": "j_arrowhead",
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-spades\">Spade</span> suit give<br><span class=\"c-chips\">+50</span> Chips when scored</div>"
+    },
+    {
+        "name": "Astronomer",
+        "image": "Astronomer.webp",
+        "status": false,
+        "id": "j_astronomer",
+        "description": "<div class=\"joker-description\">All <span class=\"c-planet\">Planet</span> cards and<br><span class=\"c-planet\">Celestial Packs</span> in<br>the shop are <span class=\"c-attention\">free</span></div>"
+    },
+    {
+        "name": "Banner",
+        "image": "Banner.webp",
+        "status": false,
+        "id": "j_banner",
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+30</span> Chips for<br>each remaining<br><span class=\"c-attention\">discard</span></div>"
+    },
+    {
+        "name": "Baron",
+        "image": "Baron.webp",
+        "status": false,
+        "id": "j_baron",
+        "description": "<div class=\"joker-description\">Each <span class=\"c-attention\">King</span><br>held in hand<br>gives <span class=\"x-mult c-red c-white\"> X1.5 </span> Mult</div>"
+    },
+    {
+        "name": "Baseball Card",
+        "image": "Baseball Card.webp",
+        "status": false,
+        "id": "j_baseball",
+        "description": "<div class=\"joker-description\"><span class=\"c-green\">Uncommon</span> Jokers<br>each give <span class=\"x-mult c-red c-white\"> X1.5 </span> Mult</div>"
+    },
+    {
+        "name": "Blackboard",
+        "image": "Blackboard.webp",
+        "status": false,
+        "id": "j_blackboard",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if all<br>cards held in hand<br>are <span class=\"c-spades\">Spades</span> or <span class=\"c-clubs\">Clubs</span></div>"
+    },
+    {
+        "name": "Bloodstone",
+        "image": "Bloodstone.webp",
+        "status": false,
+        "id": "j_bloodstone",
+        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 2</span> chance for<br>played cards with<br><span class=\"c-hearts\">Heart</span> suit to give<br><span class=\"x-mult c-red c-white\"> X1.5 </span> Mult when scored</div>"
+    },
+    {
+        "name": "Blue Joker",
+        "image": "Blue Joker.webp",
+        "status": false,
+        "id": "j_blue_joker",
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+2</span> Chips for each<br>remaining card in <span class=\"c-attention\">deck</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+52</span><span class=\"c-inactive\"> Chips)</span></div>"
+    },
+    {
+        "name": "Blueprint",
+        "image": "Blueprint.webp",
+        "status": false,
+        "id": "j_blueprint",
+        "description": "<div class=\"joker-description\">Copies ability of<br><span class=\"c-attention\">Joker</span> to the right</div>"
+    },
+    {
+        "name": "Bootstraps",
+        "image": "Bootstraps.webp",
+        "status": false,
+        "id": "j_bootstraps",
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+2</span> Mult for every<br><span class=\"c-money\">$5</span> you have<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Brainstorm",
+        "image": "Brainstorm.webp",
+        "status": false,
+        "id": "j_brainstorm",
+        "description": "<div class=\"joker-description\">Copies the ability<br>of leftmost <span class=\"c-attention\">Joker</span></div>"
+    },
+    {
+        "name": "Bull",
+        "image": "Bull.webp",
+        "status": false,
+        "id": "j_bull",
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+2</span> Chips for<br>each <span class=\"c-money\">$1</span> you have<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>"
+    },
+    {
+        "name": "Burglar",
+        "image": "Burglar.webp",
+        "status": false,
+        "id": "j_burglar",
+        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Blind</span> is selected,<br>gain <span class=\"c-blue\">+3</span> Hands and<br><span class=\"c-attention\">lose all discards</span></div>"
+    },
+    {
+        "name": "Burnt Joker",
+        "image": "Burnt Joker.webp",
+        "status": false,
+        "id": "j_burnt",
+        "description": "<div class=\"joker-description\">Upgrade the level of<br>the first <span class=\"c-attention\">discarded</span><br>poker hand each round</div>"
+    },
+    {
+        "name": "Business Card",
+        "image": "Business Card.webp",
+        "status": false,
+        "id": "j_business",
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">face</span> cards have<br>a <span class=\"c-green\">1 in 2</span> chance to<br>give <span class=\"c-money\">$2</span> when scored</div>"
+    },
+    {
+        "name": "Campfire",
+        "image": "Campfire.webp",
+        "status": false,
+        "id": "j_campfire",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\">X0.25</span> Mult<br>for each card <span class=\"c-attention\">sold</span>, resets<br>when <span class=\"c-attention\">Boss Blind</span> is defeated<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Canio",
+        "image": "Canio.webp",
+        "status": false,
+        "id": "j_caino",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X1 </span> Mult<br>when a <span class=\"c-attention\">face</span> card<br>is destroyed<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Card Sharp",
+        "image": "Card Sharp.webp",
+        "status": false,
+        "id": "j_card_sharp",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3.0 </span> Mult if played<br><span class=\"c-attention\">poker hand</span> has already<br>been played this round</div>"
+    },
+    {
+        "name": "Cartomancer",
+        "image": "Cartomancer.webp",
+        "status": false,
+        "id": "j_cartomancer",
+        "description": "<div class=\"joker-description\">Create a <span class=\"c-tarot\">Tarot</span> card<br>when <span class=\"c-attention\">Blind</span> is selected<br><span class=\"c-inactive\">(Must have room)</span></div>"
+    },
+    {
+        "name": "Castle",
+        "image": "Castle.webp",
+        "status": false,
+        "id": "j_castle",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-chips\">+3</span> Chips<br>per discarded <span class=\"variable\">Hearts</span> card,<br>suit changes every round<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>"
+    },
+    {
+        "name": "Cavendish",
+        "image": "Cavendish.webp",
+        "status": false,
+        "id": "j_cavendish",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3.0 </span> Mult<br><span class=\"c-green\">1 in 1000</span> chance this<br>card is destroyed<br>at end of round</div>"
+    },
+    {
+        "name": "Ceremonial Dagger",
+        "image": "Ceremonial Dagger.webp",
+        "status": false,
+        "id": "j_ceremonial",
+        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Blind</span> is selected,<br>destroy Joker to the right<br>and permanently add <span class=\"c-attention\">double</span><br>its sell value to this <span class=\"c-red\">Mult</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Certificate",
+        "image": "Certificate.webp",
+        "status": false,
+        "id": "j_certificate",
+        "description": "<div class=\"joker-description\">When round begins,<br>add a random <span class=\"c-attention\">playing</span><br><span class=\"c-attention\">card</span> with a random<br><span class=\"c-attention\">seal</span> to your hand</div>"
+    },
+    {
+        "name": "Chaos the Clown",
+        "image": "Chaos the Clown.webp",
+        "status": false,
+        "id": "j_chaos",
+        "description": "<div class=\"joker-description\"><span class=\"c-attention\">1</span> free <span class=\"c-green\">Reroll</span><br>per shop</div>"
+    },
+    {
+        "name": "Chicot",
+        "image": "Chicot.webp",
+        "status": false,
+        "id": "j_chicot",
+        "description": "<div class=\"joker-description\">Disables effect of<br>every <span class=\"c-attention\">Boss Blind</span></div>"
+    },
+    {
+        "name": "Clever Joker",
+        "image": "Clever Joker.webp",
+        "status": false,
+        "id": "j_clever",
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+80</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Two Pair</span></div>"
+    },
+    {
+        "name": "Cloud 9",
+        "image": "Cloud 9.webp",
+        "status": false,
+        "id": "j_cloud_9",
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$1</span> for each<br><span class=\"c-attention\">9</span> in your <span class=\"c-attention\">full deck</span><br>at end of round<br><span class=\"c-inactive\">(Currently <span class=\"c-money\">$4</span></span><span class=\"c-inactive\">)</span></div>"
+    },
+    {
+        "name": "Constellation",
+        "image": "Constellation.webp",
+        "status": false,
+        "id": "j_constellation",
+        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"x-mult c-red c-white\"> X0.1 </span> Mult every time<br>a <span class=\"c-planet\">Planet</span> card is used<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Crafty Joker",
+        "image": "Crafty Joker.webp",
+        "status": false,
+        "id": "j_crafty",
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+80</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Flush</span></div>"
+    },
+    {
+        "name": "Crazy Joker",
+        "image": "Crazy Joker.webp",
+        "status": false,
+        "id": "j_crazy",
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+12</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Straight</span></div>"
+    },
+    {
+        "name": "Credit Card",
+        "image": "Credit Card.webp",
+        "status": false,
+        "id": "j_credit_card",
+        "description": "<div class=\"joker-description\">Go up to<br><span class=\"c-red\">-$20</span> in debt</div>"
+    },
+    {
+        "name": "Delayed Gratification",
+        "image": "Delayed Gratification.webp",
+        "status": false,
+        "id": "j_delayed_grat",
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$2</span> per <span class=\"c-attention\">discard</span> if<br>no discards are used<br>by end of the round</div>"
+    },
+    {
+        "name": "Devious Joker",
+        "image": "Devious Joker.webp",
+        "status": false,
+        "id": "j_devious",
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+100</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Straight</span></div>"
+    },
+    {
+        "name": "Diet Cola",
+        "image": "Diet Cola.webp",
+        "status": false,
+        "id": "j_diet_cola",
+        "description": "<div class=\"joker-description\">Sell this card to<br>create a free<br><span class=\"c-attention\">Double Tag</span></div>"
+    },
+    {
+        "name": "DNA",
+        "image": "DNA.webp",
+        "status": false,
+        "id": "j_dna",
+        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">first hand</span> of round<br>has only <span class=\"c-attention\">1</span> card, add a<br>permanent copy to deck<br>and draw it to <span class=\"c-attention\">hand</span></div>"
+    },
+    {
+        "name": "Driver's License",
+        "image": "Driver's License.webp",
+        "status": false,
+        "id": "j_drivers_license",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X#1# </span> Mult if you have<br>at least <span class=\"c-attention\">16</span> Enhanced<br>cards in your full deck<br><span class=\"c-inactive\">(Currently </span><span class=\"c-attention\">#2#</span><span class=\"c-inactive\">)</span></div>"
+    },
+    {
+        "name": "Droll Joker",
+        "image": "Droll Joker.webp",
+        "status": false,
+        "id": "j_droll",
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+10</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Flush</span></div>"
+    },
+    {
+        "name": "Drunkard",
+        "image": "Drunkard.webp",
+        "status": false,
+        "id": "j_drunkard",
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+1</span> discard<br>each round</div>"
+    },
+    {
+        "name": "Dusk",
+        "image": "Dusk.webp",
+        "status": false,
+        "id": "j_dusk",
+        "description": "<div class=\"joker-description\">Retrigger all played<br>cards in <span class=\"c-attention\">final</span><br><span class=\"c-attention\">hand</span> of round</div>"
+    },
+    {
+        "name": "Egg",
+        "image": "Egg.webp",
+        "status": false,
+        "id": "j_egg",
+        "description": "<div class=\"joker-description\">Gains <span class=\"c-money\">$3</span> of<br><span class=\"c-attention\">sell value</span> at<br>end of round</div>"
+    },
+    {
+        "name": "Erosion",
+        "image": "Erosion.webp",
+        "status": false,
+        "id": "j_erosion",
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+4</span> Mult for each<br>card below <span class=\"c-attention\">52</span><br>in your full deck<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Even Steven",
+        "image": "Even Steven.webp",
+        "status": false,
+        "id": "j_even_steven",
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-attention\">even</span> rank give<br><span class=\"c-mult\">+4</span> Mult when scored<br><span class=\"c-inactive\">(10, 8, 6, 4, 2)</span></div>"
+    },
+    {
+        "name": "Faceless Joker",
+        "image": "Faceless Joker.webp",
+        "status": false,
+        "id": "j_faceless",
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$5</span> if <span class=\"c-attention\">3</span> or<br>more <span class=\"c-attention\">face cards</span><br>are discarded<br>at the same time</div>"
+    },
+    {
+        "name": "Fibonacci",
+        "image": "Fibonacci.webp",
+        "status": false,
+        "id": "j_fibonacci",
+        "description": "<div class=\"joker-description\">Each played <span class=\"c-attention\">Ace</span>,<br><span class=\"c-attention\">2</span>, <span class=\"c-attention\">3</span>, <span class=\"c-attention\">5</span>, or <span class=\"c-attention\">8</span> gives<br><span class=\"c-mult\">+8</span> Mult when scored</div>"
+    },
+    {
+        "name": "Flash Card",
+        "image": "Flash Card.webp",
+        "status": false,
+        "id": "j_flash",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-mult\">+2</span> Mult<br>per <span class=\"c-attention\">reroll</span> in the shop<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Flower Pot",
+        "image": "Flower Pot.webp",
+        "status": false,
+        "id": "j_flower_pot",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if poker<br>hand contains a<br><span class=\"c-diamonds\">Diamond</span> card, <span class=\"c-clubs\">Club</span> card,<br><span class=\"c-hearts\">Heart</span> card, and <span class=\"c-spades\">Spade</span> card</div>"
+    },
+    {
+        "name": "Fortune Teller",
+        "image": "Fortune Teller.webp",
+        "status": false,
+        "id": "j_fortune_teller",
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+1</span> Mult per <span class=\"c-purple\">Tarot</span><br>card used this run<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\">)</span></div>"
+    },
+    {
+        "name": "Four Fingers",
+        "image": "Four Fingers.webp",
+        "status": false,
+        "id": "j_four_fingers",
+        "description": "<div class=\"joker-description\">All <span class=\"c-attention\">Flushes</span> and<br><span class=\"c-attention\">Straights</span> can be<br>made with <span class=\"c-attention\">4</span> cards</div>"
+    },
+    {
+        "name": "Gift Card",
+        "image": "Gift Card.webp",
+        "status": false,
+        "id": "j_gift",
+        "description": "<div class=\"joker-description\">Add <span class=\"c-money\">$1</span> of <span class=\"c-attention\">sell value</span><br>to every <span class=\"c-attention\">Joker</span> and<br><span class=\"c-attention\">Consumable</span> card at<br>end of round</div>"
+    },
+    {
+        "name": "Glass Joker",
+        "image": "Glass Joker.webp",
+        "status": false,
+        "id": "j_glass",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.75 </span> Mult<br>for every <span class=\"c-attention\">Glass Card</span><br>that is destroyed<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Gluttonous Joker",
+        "image": "Gluttonous Joker.webp",
+        "status": false,
+        "id": "j_gluttenous_joker",
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-clubs\">Clubs</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>"
+    },
+    {
+        "name": "Golden Joker",
+        "image": "Golden Joker.webp",
+        "status": false,
+        "id": "j_golden",
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$4</span> at<br>end of round</div>"
+    },
+    {
+        "name": "Golden Ticket",
+        "image": "Golden Ticket.webp",
+        "status": false,
+        "id": "j_ticket",
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">Gold</span> cards<br>earn <span class=\"c-money\">$4</span> when scored</div>"
+    },
+    {
+        "name": "Greedy Joker",
+        "image": "Greedy Joker.webp",
+        "status": false,
+        "id": "j_greedy_joker",
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-diamonds\">Diamonds</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>"
+    },
+    {
+        "name": "Green Joker",
+        "image": "Green Joker.webp",
+        "status": false,
+        "id": "j_green_joker",
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+1</span> Mult per hand played<br><span class=\"c-mult\">-1</span> Mult per discard<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Gros Michel",
+        "image": "Gros Michel.webp",
+        "status": false,
+        "id": "j_gros_michel",
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+15</span> Mult<br><span class=\"c-green\">1 in 6</span> chance this<br>card is destroyed<br>at end of round</div>"
+    },
+    {
+        "name": "Hack",
+        "image": "Hack.webp",
+        "status": false,
+        "id": "j_hack",
+        "description": "<div class=\"joker-description\">Retrigger<br>each played<br><span class=\"c-attention\">2</span>, <span class=\"c-attention\">3</span>, <span class=\"c-attention\">4</span>, or <span class=\"c-attention\">5</span></div>"
+    },
+    {
+        "name": "Half Joker",
+        "image": "Half Joker.webp",
+        "status": false,
+        "id": "j_half",
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+20</span> Mult if played<br>hand contains<br><span class=\"c-attention\">3</span> or fewer cards</div>"
+    },
+    {
+        "name": "Hallucination",
+        "image": "Hallucination.webp",
+        "status": false,
+        "id": "j_hallucination",
+        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 2</span> chance to create<br>a <span class=\"c-tarot\">Tarot</span> card when any<br><span class=\"c-attention\">Booster Pack</span> is opened<br><span class=\"c-inactive\">(Must have room)</span></div>"
+    },
+    {
+        "name": "Hanging Chad",
+        "image": "Hanging Chad.webp",
+        "status": false,
+        "id": "j_hanging_chad",
+        "description": "<div class=\"joker-description\">Retrigger <span class=\"c-attention\">first</span> played<br>card used in scoring<br><span class=\"c-attention\">2</span> additional times</div>"
+    },
+    {
+        "name": "Hiker",
+        "image": "Hiker.webp",
+        "status": false,
+        "id": "j_hiker",
+        "description": "<div class=\"joker-description\">Every played <span class=\"c-attention\">card</span><br>permanently gains<br><span class=\"c-chips\">+5</span> Chips when scored</div>"
+    },
+    {
+        "name": "Hit the Road",
+        "image": "Hit the Road.webp",
+        "status": false,
+        "id": "j_hit_the_road",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.5 </span> Mult<br>for every <span class=\"c-attention\">Jack</span><br>discarded this round<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Hologram",
+        "image": "Hologram.webp",
+        "status": false,
+        "id": "j_hologram",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.25 </span> Mult<br>every time a <span class=\"c-attention\">playing card</span><br>is added to your deck<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Ice Cream",
+        "image": "Ice Cream.webp",
+        "status": false,
+        "id": "j_ice_cream",
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+100</span> Chips<br><span class=\"c-chips\">-5</span> Chips for<br>every hand played</div>"
+    },
+    {
+        "name": "Invisible Joker",
+        "image": "Invisible Joker.webp",
+        "status": false,
+        "id": "j_invisible",
+        "description": "<div class=\"joker-description\">After <span class=\"c-attention\">2</span> rounds,<br>sell this card to<br><span class=\"c-attention\">Duplicate</span> a random Joker<br><span class=\"c-inactive\">(Currently </span><span class=\"c-attention\">0</span><span class=\"c-inactive\">/2)</span></div>"
+    },
+    {
+        "name": "Joker",
+        "image": "Joker.webp",
+        "status": false,
+        "id": "j_joker",
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+4</span> Mult</div>"
+    },
+    {
+        "name": "Joker Stencil",
+        "image": "Joker Stencil.webp",
+        "status": false,
+        "id": "j_stencil",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X1 </span> Mult for each<br>empty <span class=\"c-attention\">Joker</span> slot<br><span class=\"size-0-8\">Joker Stencil included</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\">)</span></div>"
+    },
+    {
+        "name": "Jolly Joker",
+        "image": "Jolly Joker.webp",
+        "status": false,
+        "id": "j_jolly",
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+8</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Pair</span></div>"
+    },
+    {
+        "name": "Juggler",
+        "image": "Juggler.webp",
+        "status": false,
+        "id": "j_juggler",
+        "description": "<div class=\"joker-description\"><span class=\"c-attention\">+1</span> hand size</div>"
+    },
+    {
+        "name": "Loyalty Card",
+        "image": "Loyalty Card.webp",
+        "status": false,
+        "id": "j_loyalty_card",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X4.0 </span> Mult every<br><span class=\"c-attention\">6</span> hands played<br><span class=\"c-inactive\"></span></div>"
+    },
+    {
+        "name": "Luchador",
+        "image": "Luchador.webp",
+        "status": false,
+        "id": "j_luchador",
+        "description": "<div class=\"joker-description\">Sell this card to<br>disable the current<br><span class=\"c-attention\">Boss Blind</span></div>"
+    },
+    {
+        "name": "Lucky Cat",
+        "image": "Lucky Cat.webp",
+        "status": false,
+        "id": "j_lucky_cat",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.25 </span> Mult<br>every time a <span class=\"c-attention\">Lucky</span> card<br><span class=\"c-green\">successfully</span> triggers<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Lusty Joker",
+        "image": "Lusty Joker.webp",
+        "status": false,
+        "id": "j_lusty_joker",
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-hearts\">Hearts</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>"
+    },
+    {
+        "name": "Mad Joker",
+        "image": "Mad Joker.webp",
+        "status": false,
+        "id": "j_mad",
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+10</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Two Pair</span></div>"
+    },
+    {
+        "name": "Madness",
+        "image": "Madness.webp",
+        "status": false,
+        "id": "j_madness",
+        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Small Blind</span> or <span class=\"c-attention\">Big Blind</span><br>is selected, gain <span class=\"x-mult c-red c-white\"> X0.5 </span> Mult<br>and <span class=\"c-attention\">destroy</span> a random Joker<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Mail-In Rebate",
+        "image": "Mail-In Rebate.webp",
+        "status": false,
+        "id": "j_mail",
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$5</span> for each<br>discarded <span class=\"c-attention\">2</span>, rank<br>changes every round</div>"
+    },
+    {
+        "name": "Marble Joker",
+        "image": "Marble Joker.webp",
+        "status": false,
+        "id": "j_marble",
+        "description": "<div class=\"joker-description\">Adds one <span class=\"c-attention\">Stone</span> card<br>to deck when<br><span class=\"c-attention\">Blind</span> is selected</div>"
+    },
+    {
+        "name": "Matador",
+        "image": "Matador.webp",
+        "status": false,
+        "id": "j_matador",
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$8</span> if played<br>hand triggers the<br><span class=\"c-attention\">Boss Blind</span> ability</div>"
+    },
+    {
+        "name": "Merry Andy",
+        "image": "Merry Andy.webp",
+        "status": false,
+        "id": "j_merry_andy",
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+3</span> discards<br>each round,<br><span class=\"c-red\">-1</span> hand size</div>"
+    },
+    {
+        "name": "Midas Mask",
+        "image": "Midas Mask.webp",
+        "status": false,
+        "id": "j_midas_mask",
+        "description": "<div class=\"joker-description\">All played <span class=\"c-attention\">face</span> cards<br>become <span class=\"c-attention\">Gold</span> cards<br>when scored</div>"
+    },
+    {
+        "name": "Mime",
+        "image": "Mime.webp",
+        "status": false,
+        "id": "j_mime",
+        "description": "<div class=\"joker-description\">Retrigger all<br>card <span class=\"c-attention\">held in</span><br><span class=\"c-attention\">hand</span> abilities</div>"
+    },
+    {
+        "name": "Misprint",
+        "image": "Misprint.webp",
+        "status": false,
+        "id": "j_misprint",
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+[0 to 23]</span> Mult</div>"
+    },
+    {
+        "name": "Mr. Bones",
+        "image": "Mr. Bones.webp",
+        "status": false,
+        "id": "j_mr_bones",
+        "description": "<div class=\"joker-description\">Prevents Death<br>if chips scored<br>are at least <span class=\"c-attention\">25%</span><br>of required chips<br><span class=\"size-1-1 c-red enhanced-text\">self destructs</span></div>"
+    },
+    {
+        "name": "Mystic Summit",
+        "image": "Mystic Summit.webp",
+        "status": false,
+        "id": "j_mystic_summit",
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+15</span> Mult when<br><span class=\"c-attention\">0</span> discards<br>remaining</div>"
+    },
+    {
+        "name": "Obelisk",
+        "image": "Obelisk.webp",
+        "status": false,
+        "id": "j_obelisk",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.2 </span> Mult<br>per <span class=\"c-attention\">consecutive</span> hand played<br>without playing your<br>most played <span class=\"c-attention\">poker hand</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Odd Todd",
+        "image": "Odd Todd.webp",
+        "status": false,
+        "id": "j_odd_todd",
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-attention\">odd</span> rank give<br><span class=\"c-chips\">+31</span> Chips when scored<br><span class=\"c-inactive\">(A, 9, 7, 5, 3)</span></div>"
+    },
+    {
+        "name": "Onyx Agate",
+        "image": "Onyx Agate.webp",
+        "status": false,
+        "id": "j_onyx_agate",
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-clubs\">Club</span> suit give<br><span class=\"c-mult\">+7</span> Mult when scored</div>"
+    },
+    {
+        "name": "Oops! All 6s",
+        "image": "Oops! All 6s.webp",
+        "status": false,
+        "id": "j_oops",
+        "description": "<div class=\"joker-description\">Doubles all <span class=\"c-attention\">listed</span><br><span class=\"c-green c-e:1 c-s:1.1\">probabilities</span><br><span class=\"c-inactive\">(ex: </span><span class=\"c-green\">1 in 3</span><span class=\"c-inactive\"> -> </span><span class=\"c-green\">2 in 3</span><span class=\"c-inactive\">)</span></div>"
+    },
+    {
+        "name": "Pareidolia",
+        "image": "Pareidolia.webp",
+        "status": false,
+        "id": "j_pareidolia",
+        "description": "<div class=\"joker-description\">All cards are<br>considered<br><span class=\"c-attention\">face</span> cards</div>"
+    },
+    {
+        "name": "Perkeo",
+        "image": "Perkeo.webp",
+        "status": false,
+        "id": "j_perkeo",
+        "description": "<div class=\"joker-description\">Creates a <span class=\"c-dark-edition\">Negative</span> copy of<br><span class=\"c-attention\">1</span> random <span class=\"c-attention\">consumable</span><br>card in your possession<br>at the end of the <span class=\"c-attention\">shop</span></div>"
+    },
+    {
+        "name": "Photograph",
+        "image": "Photograph.webp",
+        "status": false,
+        "id": "j_photograph",
+        "description": "<div class=\"joker-description\">First played <span class=\"c-attention\">face</span><br>card gives <span class=\"x-mult c-red c-white\"> X2 </span> Mult<br>when scored</div>"
+    },
+    {
+        "name": "Popcorn",
+        "image": "Popcorn.webp",
+        "status": false,
+        "id": "j_popcorn",
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+20</span> Mult<br><span class=\"c-mult\">-4</span> Mult per<br>round played</div>"
+    },
+    {
+        "name": "Raised Fist",
+        "image": "Raised Fist.webp",
+        "status": false,
+        "id": "j_raised_fist",
+        "description": "<div class=\"joker-description\">Adds <span class=\"c-attention\">double</span> the rank<br>of <span class=\"c-attention\">lowest</span> ranked card<br>held in hand to Mult</div>"
+    },
+    {
+        "name": "Ramen",
+        "image": "Ramen.webp",
+        "status": false,
+        "id": "j_ramen",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult,<br>loses <span class=\"x-mult c-red c-white\"> X0.01 </span> Mult<br>per <span class=\"c-attention\">card</span> discarded</div>"
+    },
+    {
+        "name": "Red Card",
+        "image": "Red Card.webp",
+        "status": false,
+        "id": "j_red_card",
+        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"c-red\">+3</span> Mult when any<br><span class=\"c-attention\">Booster Pack</span> is skipped<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Reserved Parking",
+        "image": "Reserved Parking.webp",
+        "status": false,
+        "id": "j_reserved_parking",
+        "description": "<div class=\"joker-description\">Each <span class=\"c-attention\">face</span> card<br>held in hand has<br>a <span class=\"c-green\">1 in 2</span> chance<br>to give <span class=\"c-money\">$1</span></div>"
+    },
+    {
+        "name": "Ride the Bus",
+        "image": "Ride the Bus.webp",
+        "status": false,
+        "id": "j_ride_the_bus",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-mult\">+1</span> Mult<br>per <span class=\"c-attention\">consecutive</span> hand<br>played without a<br>scoring <span class=\"c-attention\">face</span> card<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Riff-Raff",
+        "image": "Riff-Raff.webp",
+        "status": false,
+        "id": "j_riff_raff",
+        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Blind</span> is selected,<br>create <span class=\"c-attention\">2 </span><span class=\"c-blue\">Common</span><span class=\"c-attention\"> Jokers</span><br><span class=\"c-inactive\">(Must have room)</span></div>"
+    },
+    {
+        "name": "Rocket",
+        "image": "Rocket.webp",
+        "status": false,
+        "id": "j_rocket",
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$1</span> at end of round<br>Payout increases by <span class=\"c-money\">$2</span><br>when <span class=\"c-attention\">Boss Blind</span> is defeated</div>"
+    },
+    {
+        "name": "Rough Gem",
+        "image": "Rough Gem.webp",
+        "status": false,
+        "id": "j_rough_gem",
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-diamonds\">Diamond</span> suit earn<br><span class=\"c-money\">$1</span> when scored</div>"
+    },
+    {
+        "name": "Runner",
+        "image": "Runner.webp",
+        "status": false,
+        "id": "j_runner",
+        "description": "<div class=\"joker-description\">Gains <span class=\"c-chips\">+15</span> Chips<br>if played hand<br>contains a <span class=\"c-attention\">Straight</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>"
+    },
+    {
+        "name": "Satellite",
+        "image": "Satellite.webp",
+        "status": false,
+        "id": "j_satellite",
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$1</span> at end of<br>round per unique <span class=\"c-planet\">Planet</span><br>card used this run<br><span class=\"c-inactive\">(Currently </span><span class=\"c-money\">$0</span><span class=\"c-inactive\">)</span></div>"
+    },
+    {
+        "name": "Scary Face",
+        "image": "Scary Face.webp",
+        "status": false,
+        "id": "j_scary_face",
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">face</span> cards<br>give <span class=\"c-chips\">+30</span> Chips<br>when scored</div>"
+    },
+    {
+        "name": "Scholar",
+        "image": "Scholar.webp",
+        "status": false,
+        "id": "j_scholar",
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">Aces</span><br>give <span class=\"c-chips\">+20</span> Chips<br>and <span class=\"c-mult\">+4</span> Mult<br>when scored</div>"
+    },
+    {
+        "name": "S\u00e9ance",
+        "image": "S\u00e9ance.webp",
+        "status": false,
+        "id": "j_seance",
+        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">poker hand</span> is a<br><span class=\"c-attention\">Straight Flush</span>, create a<br>random <span class=\"c-spectral\">Spectral</span> card<br><span class=\"c-inactive\">(Must have room)</span></div>"
+    },
+    {
+        "name": "Seeing Double",
+        "image": "Seeing Double.webp",
+        "status": false,
+        "id": "j_seeing_double",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult if played<br>hand has a scoring<br><span class=\"c-clubs\">Club</span> card and a scoring<br>card of any other <span class=\"c-attention\">suit</span></div>"
+    },
+    {
+        "name": "Seltzer",
+        "image": "Seltzer.webp",
+        "status": false,
+        "id": "j_selzer",
+        "description": "<div class=\"joker-description\">Retrigger all<br>cards played for<br>the next <span class=\"c-attention\">10</span> hands</div>"
+    },
+    {
+        "name": "Shoot the Moon",
+        "image": "Shoot the Moon.webp",
+        "status": false,
+        "id": "j_shoot_the_moon",
+        "description": "<div class=\"joker-description\">Each <span class=\"c-attention\">Queen</span><br>held in hand<br>gives <span class=\"c-mult\">+13</span> Mult</div>"
+    },
+    {
+        "name": "Shortcut",
+        "image": "Shortcut.webp",
+        "status": false,
+        "id": "j_shortcut",
+        "description": "<div class=\"joker-description\">Allows <span class=\"c-attention\">Straights</span> to be<br>made with gaps of <span class=\"c-attention\">1 rank</span><br><span class=\"c-inactive\">(ex: </span><span class=\"c-attention\">10 8 6 5 3</span><span class=\"c-inactive\">)</span></div>"
+    },
+    {
+        "name": "Showman",
+        "image": "Showman.webp",
+        "status": false,
+        "id": "j_ring_master",
+        "description": "<div class=\"joker-description\"><span class=\"c-attention\">Joker</span>, <span class=\"c-tarot\">Tarot</span>, <span class=\"c-planet\">Planet</span>,<br>and <span class=\"c-spectral\">Spectral</span> cards may<br>appear multiple times</div>"
+    },
+    {
+        "name": "Sixth Sense",
+        "image": "Sixth Sense.webp",
+        "status": false,
+        "id": "j_sixth_sense",
+        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">first hand</span> of round is<br>a single <span class=\"c-attention\">6</span>, destroy it and<br>create a <span class=\"c-spectral\">Spectral</span> card<br><span class=\"c-inactive\">(Must have room)</span></div>"
+    },
+    {
+        "name": "Sly Joker",
+        "image": "Sly Joker.webp",
+        "status": false,
+        "id": "j_sly",
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+50</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Pair</span></div>"
+    },
+    {
+        "name": "Smeared Joker",
+        "image": "Smeared Joker.webp",
+        "status": false,
+        "id": "j_smeared",
+        "description": "<div class=\"joker-description\"><span class=\"c-hearts\">Hearts</span> and <span class=\"c-diamonds\">Diamonds</span><br>count as the same suit,<br><span class=\"c-spades\">Spades</span> and <span class=\"c-clubs\">Clubs</span><br>count as the same suit</div>"
+    },
+    {
+        "name": "Smiley Face",
+        "image": "Smiley Face.webp",
+        "status": false,
+        "id": "j_smiley",
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">face</span> cards<br>give <span class=\"c-mult\">+5</span> Mult<br>when scored</div>"
+    },
+    {
+        "name": "Sock and Buskin",
+        "image": "Sock and Buskin.webp",
+        "status": false,
+        "id": "j_sock_and_buskin",
+        "description": "<div class=\"joker-description\">Retrigger all<br>played <span class=\"c-attention\">face</span> cards</div>"
+    },
+    {
+        "name": "Space Joker",
+        "image": "Space Joker.webp",
+        "status": false,
+        "id": "j_space",
+        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 4</span> chance to<br>upgrade level of<br>played <span class=\"c-attention\">poker hand</span></div>"
+    },
+    {
+        "name": "Spare Trousers",
+        "image": "Spare Trousers.webp",
+        "status": false,
+        "id": "j_trousers",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-mult\">+2</span> Mult<br>if played hand contains<br>a <span class=\"c-attention\">Two Pair</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Splash",
+        "image": "Splash.webp",
+        "status": false,
+        "id": "j_splash",
+        "description": "<div class=\"joker-description\">Every <span class=\"c-attention\">played card</span><br>counts in scoring</div>"
+    },
+    {
+        "name": "Square Joker",
+        "image": "Square Joker.webp",
+        "status": false,
+        "id": "j_square",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-chips\">+4</span> Chips<br>if played hand has<br>exactly <span class=\"c-attention\">4</span> cards<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">0</span><span class=\"c-inactive\"> Chips)</span></div>"
+    },
+    {
+        "name": "Steel Joker",
+        "image": "Steel Joker.webp",
+        "status": false,
+        "id": "j_steel_joker",
+        "description": "<div class=\"joker-description\">Gives <span class=\"x-mult c-red c-white\"> X0.2 </span> Mult<br>for each <span class=\"c-attention\">Steel Card</span><br>in your <span class=\"c-attention\">full deck</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Stone Joker",
+        "image": "Stone Joker.webp",
+        "status": false,
+        "id": "j_stone",
+        "description": "<div class=\"joker-description\">Gives <span class=\"c-chips\">+25</span> Chips for<br>each <span class=\"c-attention\">Stone Card</span><br>in your <span class=\"c-attention\">full deck</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>"
+    },
+    {
+        "name": "Stuntman",
+        "image": "Stuntman.webp",
+        "status": false,
+        "id": "j_stuntman",
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+250</span> Chips,<br><span class=\"c-attention\">-2</span> hand size</div>"
+    },
+    {
+        "name": "Supernova",
+        "image": "Supernova.webp",
+        "status": false,
+        "id": "j_supernova",
+        "description": "<div class=\"joker-description\">Adds the number of times<br><span class=\"c-attention\">poker hand</span> has been<br>played this run to Mult</div>"
+    },
+    {
+        "name": "Superposition",
+        "image": "Superposition.webp",
+        "status": false,
+        "id": "j_superposition",
+        "description": "<div class=\"joker-description\">Create a <span class=\"c-tarot\">Tarot</span> card if<br>poker hand contains an<br><span class=\"c-attention\">Ace</span> and a <span class=\"c-attention\">Straight</span><br><span class=\"c-inactive\">(Must have room)</span></div>"
+    },
+    {
+        "name": "Swashbuckler",
+        "image": "Swashbuckler.webp",
+        "status": false,
+        "id": "j_swashbuckler",
+        "description": "<div class=\"joker-description\">Adds the sell value<br>of all other owned<br><span class=\"c-attention\">Jokers</span> to Mult<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+1</span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "The Duo",
+        "image": "The Duo.webp",
+        "status": false,
+        "id": "j_duo",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Pair</span></div>"
+    },
+    {
+        "name": "The Family",
+        "image": "The Family.webp",
+        "status": false,
+        "id": "j_family",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X4 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Four of a Kind</span></div>"
+    },
+    {
+        "name": "The Idol",
+        "image": "The Idol.webp",
+        "status": false,
+        "id": "j_idol",
+        "description": "<div class=\"joker-description\">Each played <span class=\"c-attention\">2</span><br>of <span class=\"variable\">Spades</span> gives<br><span class=\"x-mult c-red c-white\"> X2 </span> Mult when scored<br><span class=\"size-0-8\">Card changes every round</span></div>"
+    },
+    {
+        "name": "The Order",
+        "image": "The Order.webp",
+        "status": false,
+        "id": "j_order",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Straight</span></div>"
+    },
+    {
+        "name": "The Tribe",
+        "image": "The Tribe.webp",
+        "status": false,
+        "id": "j_tribe",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Flush</span></div>"
+    },
+    {
+        "name": "The Trio",
+        "image": "The Trio.webp",
+        "status": false,
+        "id": "j_trio",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Three of a Kind</span></div>"
+    },
+    {
+        "name": "Throwback",
+        "image": "Throwback.webp",
+        "status": false,
+        "id": "j_throwback",
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X0.25 </span> Mult for each<br><span class=\"c-attention\">Blind</span> skipped this run<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "To Do List",
+        "image": "To Do List.webp",
+        "status": false,
+        "id": "j_todo_list",
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$4</span> if <span class=\"c-attention\">poker hand</span><br>is a <span class=\"c-attention\">High Card</span>,<br>poker hand changes<br>at end of round</div>"
+    },
+    {
+        "name": "To the Moon",
+        "image": "To the Moon.webp",
+        "status": false,
+        "id": "j_to_the_moon",
+        "description": "<div class=\"joker-description\">Earn an extra <span class=\"c-money\">$1</span> of<br><span class=\"c-attention\">interest</span> for every <span class=\"c-money\">$5</span> you<br>have at end of round</div>"
+    },
+    {
+        "name": "Trading Card",
+        "image": "Trading Card.webp",
+        "status": false,
+        "id": "j_trading",
+        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">first discard</span> of round<br>has only <span class=\"c-attention\">1</span> card, destroy<br>it and earn <span class=\"c-money\">$3</span></div>"
+    },
+    {
+        "name": "Triboulet",
+        "image": "Triboulet.webp",
+        "status": false,
+        "id": "j_triboulet",
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">Kings</span> and<br><span class=\"c-attention\">Queens</span> each give<br><span class=\"x-mult c-red c-white\"> X2 </span> Mult when scored</div>"
+    },
+    {
+        "name": "Troubadour",
+        "image": "Troubadour.webp",
+        "status": false,
+        "id": "j_troubadour",
+        "description": "<div class=\"joker-description\"><span class=\"c-attention\">+2</span> hand size,<br><span class=\"c-blue\">-1</span> hand each round</div>"
+    },
+    {
+        "name": "Turtle Bean",
+        "image": "Turtle Bean.webp",
+        "status": false,
+        "id": "j_turtle_bean",
+        "description": "<div class=\"joker-description\"><span class=\"c-attention\">+5</span> hand size,<br>reduces by<br><span class=\"c-red\">1</span> every round</div>"
+    },
+    {
+        "name": "Vagabond",
+        "image": "Vagabond.webp",
+        "status": false,
+        "id": "j_vagabond",
+        "description": "<div class=\"joker-description\">Create a <span class=\"c-purple\">Tarot</span> card<br>if hand is played<br>with <span class=\"c-money\">$4</span> or less</div>"
+    },
+    {
+        "name": "Vampire",
+        "image": "Vampire.webp",
+        "status": false,
+        "id": "j_vampire",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.1 </span> Mult<br>per scoring <span class=\"c-attention\">Enhanced card</span> played,<br>removes card <span class=\"c-attention\">Enhancement</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Walkie Talkie",
+        "image": "Walkie Talkie.webp",
+        "status": false,
+        "id": "j_walkie_talkie",
+        "description": "<div class=\"joker-description\">Each played <span class=\"c-attention\">10</span> or <span class=\"c-attention\">4</span><br>gives <span class=\"c-chips\">+10</span> Chips and<br><span class=\"c-mult\">+4</span> Mult when scored</div>"
+    },
+    {
+        "name": "Wee Joker",
+        "image": "Wee Joker.webp",
+        "status": false,
+        "id": "j_wee",
+        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"c-chips\">+8</span> Chips when each<br>played <span class=\"c-attention\">2</span> is scored<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>"
+    },
+    {
+        "name": "Wily Joker",
+        "image": "Wily Joker.webp",
+        "status": false,
+        "id": "j_wily",
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+100</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Three of a Kind</span></div>"
+    },
+    {
+        "name": "Wrathful Joker",
+        "image": "Wrathful Joker.webp",
+        "status": false,
+        "id": "j_wrathful_joker",
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-spades\">Spades</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>"
+    },
+    {
+        "name": "Yorick",
+        "image": "Yorick.webp",
+        "status": false,
+        "id": "j_yorick",
+        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"x-mult c-red c-white\"> X1 </span> Mult every <span class=\"c-attention\">23<span class=\"c-inactive\"> [23]</span></span><br>cards discarded<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+    },
+    {
+        "name": "Zany Joker",
+        "image": "Zany Joker.webp",
+        "status": false,
+        "id": "j_zany",
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+12</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Three of a Kind</span></div>"
+    }
 ]

--- a/static/jokers.json
+++ b/static/jokers.json
@@ -1052,7 +1052,7 @@
         "image": "The Idol.webp",
         "status": false,
         "id": "j_idol",
-        "description": "<div class=\"joker-description\">Each played <span class=\"c-attention\">2</span><br>of <span class=\"variable\">Spades</span> gives<br><span class=\"x-mult c-red c-white\"> X2 </span> Mult when scored<br><span class=\"size-0-8\">Card changes every round</span></div>",
+        "description": "<div class=\"joker-description\">Each played <span class=\"c-attention\">[random owned rank]</span><br>of <span class=\"variable\">[random owned suit]</span> gives<br><span class=\"x-mult c-red c-white\"> X2 </span> Mult when scored<br><span class=\"size-0-8\">Card changes every round</span></div>",
         "rarity": 2
     },
     {

--- a/static/jokers.json
+++ b/static/jokers.json
@@ -1,902 +1,1052 @@
 [
-    {
-        "name": "8 Ball",
-        "image": "8 Ball.webp",
-        "status": false,
-        "id": "j_8_ball"
-    },
-    {
-        "name": "Abstract Joker",
-        "image": "Abstract Joker.webp",
-        "status": false,
-        "id": "j_abstract"
-    },
-    {
-        "name": "Acrobat",
-        "image": "Acrobat.webp",
-        "status": false,
-        "id": "j_acrobat"
-    },
-    {
-        "name": "Ancient Joker",
-        "image": "Ancient Joker.webp",
-        "status": false,
-        "id": "j_ancient"
-    },
-    {
-        "name": "Arrowhead",
-        "image": "Arrowhead.webp",
-        "status": false,
-        "id": "j_arrowhead"
-    },
-    {
-        "name": "Astronomer",
-        "image": "Astronomer.webp",
-        "status": false,
-        "id": "j_astronomer"
-    },
-    {
-        "name": "Banner",
-        "image": "Banner.webp",
-        "status": false,
-        "id": "j_banner"
-    },
-    {
-        "name": "Baron",
-        "image": "Baron.webp",
-        "status": false,
-        "id": "j_baron"
-    },
-    {
-        "name": "Baseball Card",
-        "image": "Baseball Card.webp",
-        "status": false,
-        "id": "j_baseball"
-    },
-    {
-        "name": "Blackboard",
-        "image": "Blackboard.webp",
-        "status": false,
-        "id": "j_blackboard"
-    },
-    {
-        "name": "Bloodstone",
-        "image": "Bloodstone.webp",
-        "status": false,
-        "id": "j_bloodstone"
-    },
-    {
-        "name": "Blue Joker",
-        "image": "Blue Joker.webp",
-        "status": false,
-        "id": "j_blue_joker"
-    },
-    {
-        "name": "Blueprint",
-        "image": "Blueprint.webp",
-        "status": false,
-        "id": "j_blueprint"
-    },
-    {
-        "name": "Bootstraps",
-        "image": "Bootstraps.webp",
-        "status": false,
-        "id": "j_bootstraps"
-    },
-    {
-        "name": "Brainstorm",
-        "image": "Brainstorm.webp",
-        "status": false,
-        "id": "j_brainstorm"
-    },
-    {
-        "name": "Bull",
-        "image": "Bull.webp",
-        "status": false,
-        "id": "j_bull"
-    },
-    {
-        "name": "Burglar",
-        "image": "Burglar.webp",
-        "status": false,
-        "id": "j_burglar"
-    },
-    {
-        "name": "Burnt Joker",
-        "image": "Burnt Joker.webp",
-        "status": false,
-        "id": "j_burnt"
-    },
-    {
-        "name": "Business Card",
-        "image": "Business Card.webp",
-        "status": false,
-        "id": "j_business"
-    },
-    {
-        "name": "Campfire",
-        "image": "Campfire.webp",
-        "status": false,
-        "id": "j_campfire"
-    },
-    {
-        "name": "Canio",
-        "image": "Canio.webp",
-        "status": false,
-        "id": "j_caino"
-    },
-    {
-        "name": "Card Sharp",
-        "image": "Card Sharp.webp",
-        "status": false,
-        "id": "j_card_sharp"
-    },
-    {
-        "name": "Cartomancer",
-        "image": "Cartomancer.webp",
-        "status": false,
-        "id": "j_cartomancer"
-    },
-    {
-        "name": "Castle",
-        "image": "Castle.webp",
-        "status": false,
-        "id": "j_castle"
-    },
-    {
-        "name": "Cavendish",
-        "image": "Cavendish.webp",
-        "status": false,
-        "id": "j_cavendish"
-    },
-    {
-        "name": "Ceremonial Dagger",
-        "image": "Ceremonial Dagger.webp",
-        "status": false,
-        "id": "j_ceremonial"
-    },
-    {
-        "name": "Certificate",
-        "image": "Certificate.webp",
-        "status": false,
-        "id": "j_certificate"
-    },
-    {
-        "name": "Chaos the Clown",
-        "image": "Chaos the Clown.webp",
-        "status": false,
-        "id": "j_chaos"
-    },
-    {
-        "name": "Chicot",
-        "image": "Chicot.webp",
-        "status": false,
-        "id": "j_chicot"
-    },
-    {
-        "name": "Clever Joker",
-        "image": "Clever Joker.webp",
-        "status": false,
-        "id": "j_clever"
-    },
-    {
-        "name": "Cloud 9",
-        "image": "Cloud 9.webp",
-        "status": false,
-        "id": "j_cloud_9"
-    },
-    {
-        "name": "Constellation",
-        "image": "Constellation.webp",
-        "status": false,
-        "id": "j_constellation"
-    },
-    {
-        "name": "Crafty Joker",
-        "image": "Crafty Joker.webp",
-        "status": false,
-        "id": "j_crafty"
-    },
-    {
-        "name": "Crazy Joker",
-        "image": "Crazy Joker.webp",
-        "status": false,
-        "id": "j_crazy"
-    },
-    {
-        "name": "Credit Card",
-        "image": "Credit Card.webp",
-        "status": false,
-        "id": "j_credit_card"
-    },
-    {
-        "name": "Delayed Gratification",
-        "image": "Delayed Gratification.webp",
-        "status": false,
-        "id": "j_delayed_grat"
-    },
-    {
-        "name": "Devious Joker",
-        "image": "Devious Joker.webp",
-        "status": false,
-        "id": "j_devious"
-    },
-    {
-        "name": "Diet Cola",
-        "image": "Diet Cola.webp",
-        "status": false,
-        "id": "j_diet_cola"
-    },
-    {
-        "name": "DNA",
-        "image": "DNA.webp",
-        "status": false,
-        "id": "j_dna"
-    },
-    {
-        "name": "Driver's License",
-        "image": "Driver's License.webp",
-        "status": false,
-        "id": "j_drivers_license"
-    },
-    {
-        "name": "Droll Joker",
-        "image": "Droll Joker.webp",
-        "status": false,
-        "id": "j_droll"
-    },
-    {
-        "name": "Drunkard",
-        "image": "Drunkard.webp",
-        "status": false,
-        "id": "j_drunkard"
-    },
-    {
-        "name": "Dusk",
-        "image": "Dusk.webp",
-        "status": false,
-        "id": "j_dusk"
-    },
-    {
-        "name": "Egg",
-        "image": "Egg.webp",
-        "status": false,
-        "id": "j_egg"
-    },
-    {
-        "name": "Erosion",
-        "image": "Erosion.webp",
-        "status": false,
-        "id": "j_erosion"
-    },
-    {
-        "name": "Even Steven",
-        "image": "Even Steven.webp",
-        "status": false,
-        "id": "j_even_steven"
-    },
-    {
-        "name": "Faceless Joker",
-        "image": "Faceless Joker.webp",
-        "status": false,
-        "id": "j_faceless"
-    },
-    {
-        "name": "Fibonacci",
-        "image": "Fibonacci.webp",
-        "status": false,
-        "id": "j_fibonacci"
-    },
-    {
-        "name": "Flash Card",
-        "image": "Flash Card.webp",
-        "status": false,
-        "id": "j_flash"
-    },
-    {
-        "name": "Flower Pot",
-        "image": "Flower Pot.webp",
-        "status": false,
-        "id": "j_flower_pot"
-    },
-    {
-        "name": "Fortune Teller",
-        "image": "Fortune Teller.webp",
-        "status": false,
-        "id": "j_fortune_teller"
-    },
-    {
-        "name": "Four Fingers",
-        "image": "Four Fingers.webp",
-        "status": false,
-        "id": "j_four_fingers"
-    },
-    {
-        "name": "Gift Card",
-        "image": "Gift Card.webp",
-        "status": false,
-        "id": "j_gift"
-    },
-    {
-        "name": "Glass Joker",
-        "image": "Glass Joker.webp",
-        "status": false,
-        "id": "j_glass"
-    },
-    {
-        "name": "Gluttonous Joker",
-        "image": "Gluttonous Joker.webp",
-        "status": false,
-        "id": "j_gluttenous_joker"
-    },
-    {
-        "name": "Golden Joker",
-        "image": "Golden Joker.webp",
-        "status": false,
-        "id": "j_golden"
-    },
-    {
-        "name": "Golden Ticket",
-        "image": "Golden Ticket.webp",
-        "status": false,
-        "id": "j_ticket"
-    },
-    {
-        "name": "Greedy Joker",
-        "image": "Greedy Joker.webp",
-        "status": false,
-        "id": "j_greedy_joker"
-    },
-    {
-        "name": "Green Joker",
-        "image": "Green Joker.webp",
-        "status": false,
-        "id": "j_green_joker"
-    },
-    {
-        "name": "Gros Michel",
-        "image": "Gros Michel.webp",
-        "status": false,
-        "id": "j_gros_michel"
-    },
-    {
-        "name": "Hack",
-        "image": "Hack.webp",
-        "status": false,
-        "id": "j_hack"
-    },
-    {
-        "name": "Half Joker",
-        "image": "Half Joker.webp",
-        "status": false,
-        "id": "j_half"
-    },
-    {
-        "name": "Hallucination",
-        "image": "Hallucination.webp",
-        "status": false,
-        "id": "j_hallucination"
-    },
-    {
-        "name": "Hanging Chad",
-        "image": "Hanging Chad.webp",
-        "status": false,
-        "id": "j_hanging_chad"
-    },
-    {
-        "name": "Hiker",
-        "image": "Hiker.webp",
-        "status": false,
-        "id": "j_hiker"
-    },
-    {
-        "name": "Hit the Road",
-        "image": "Hit the Road.webp",
-        "status": false,
-        "id": "j_hit_the_road"
-    },
-    {
-        "name": "Hologram",
-        "image": "Hologram.webp",
-        "status": false,
-        "id": "j_hologram"
-    },
-    {
-        "name": "Ice Cream",
-        "image": "Ice Cream.webp",
-        "status": false,
-        "id": "j_ice_cream"
-    },
-    {
-        "name": "Invisible Joker",
-        "image": "Invisible Joker.webp",
-        "status": false,
-        "id": "j_invisible"
-    },
-    {
-        "name": "Joker",
-        "image": "Joker.webp",
-        "status": false,
-        "id": "j_joker"
-    },
-    {
-        "name": "Joker Stencil",
-        "image": "Joker Stencil.webp",
-        "status": false,
-        "id": "j_stencil"
-    },
-    {
-        "name": "Jolly Joker",
-        "image": "Jolly Joker.webp",
-        "status": false,
-        "id": "j_jolly"
-    },
-    {
-        "name": "Juggler",
-        "image": "Juggler.webp",
-        "status": false,
-        "id": "j_juggler"
-    },
-    {
-        "name": "Loyalty Card",
-        "image": "Loyalty Card.webp",
-        "status": false,
-        "id": "j_loyalty_card"
-    },
-    {
-        "name": "Luchador",
-        "image": "Luchador.webp",
-        "status": false,
-        "id": "j_luchador"
-    },
-    {
-        "name": "Lucky Cat",
-        "image": "Lucky Cat.webp",
-        "status": false,
-        "id": "j_lucky_cat"
-    },
-    {
-        "name": "Lusty Joker",
-        "image": "Lusty Joker.webp",
-        "status": false,
-        "id": "j_lusty_joker"
-    },
-    {
-        "name": "Mad Joker",
-        "image": "Mad Joker.webp",
-        "status": false,
-        "id": "j_mad"
-    },
-    {
-        "name": "Madness",
-        "image": "Madness.webp",
-        "status": false,
-        "id": "j_madness"
-    },
-    {
-        "name": "Mail-In Rebate",
-        "image": "Mail-In Rebate.webp",
-        "status": false,
-        "id": "j_mail"
-    },
-    {
-        "name": "Marble Joker",
-        "image": "Marble Joker.webp",
-        "status": false,
-        "id": "j_marble"
-    },
-    {
-        "name": "Matador",
-        "image": "Matador.webp",
-        "status": false,
-        "id": "j_matador"
-    },
-    {
-        "name": "Merry Andy",
-        "image": "Merry Andy.webp",
-        "status": false,
-        "id": "j_merry_andy"
-    },
-    {
-        "name": "Midas Mask",
-        "image": "Midas Mask.webp",
-        "status": false,
-        "id": "j_midas_mask"
-    },
-    {
-        "name": "Mime",
-        "image": "Mime.webp",
-        "status": false,
-        "id": "j_mime"
-    },
-    {
-        "name": "Misprint",
-        "image": "Misprint.webp",
-        "status": false,
-        "id": "j_misprint"
-    },
-    {
-        "name": "Mr. Bones",
-        "image": "Mr. Bones.webp",
-        "status": false,
-        "id": "j_mr_bones"
-    },
-    {
-        "name": "Mystic Summit",
-        "image": "Mystic Summit.webp",
-        "status": false,
-        "id": "j_mystic_summit"
-    },
-    {
-        "name": "Obelisk",
-        "image": "Obelisk.webp",
-        "status": false,
-        "id": "j_obelisk"
-    },
-    {
-        "name": "Odd Todd",
-        "image": "Odd Todd.webp",
-        "status": false,
-        "id": "j_odd_todd"
-    },
-    {
-        "name": "Onyx Agate",
-        "image": "Onyx Agate.webp",
-        "status": false,
-        "id": "j_onyx_agate"
-    },
-    {
-        "name": "Oops! All 6s",
-        "image": "Oops! All 6s.webp",
-        "status": false,
-        "id": "j_oops"
-    },
-    {
-        "name": "Pareidolia",
-        "image": "Pareidolia.webp",
-        "status": false,
-        "id": "j_pareidolia"
-    },
-    {
-        "name": "Perkeo",
-        "image": "Perkeo.webp",
-        "status": false,
-        "id": "j_perkeo"
-    },
-    {
-        "name": "Photograph",
-        "image": "Photograph.webp",
-        "status": false,
-        "id": "j_photograph"
-    },
-    {
-        "name": "Popcorn",
-        "image": "Popcorn.webp",
-        "status": false,
-        "id": "j_popcorn"
-    },
-    {
-        "name": "Raised Fist",
-        "image": "Raised Fist.webp",
-        "status": false,
-        "id": "j_raised_fist"
-    },
-    {
-        "name": "Ramen",
-        "image": "Ramen.webp",
-        "status": false,
-        "id": "j_ramen"
-    },
-    {
-        "name": "Red Card",
-        "image": "Red Card.webp",
-        "status": false,
-        "id": "j_red_card"
-    },
-    {
-        "name": "Reserved Parking",
-        "image": "Reserved Parking.webp",
-        "status": false,
-        "id": "j_reserved_parking"
-    },
-    {
-        "name": "Ride the Bus",
-        "image": "Ride the Bus.webp",
-        "status": false,
-        "id": "j_ride_the_bus"
-    },
-    {
-        "name": "Riff-Raff",
-        "image": "Riff-Raff.webp",
-        "status": false,
-        "id": "j_riff_raff"
-    },
-    {
-        "name": "Rocket",
-        "image": "Rocket.webp",
-        "status": false,
-        "id": "j_rocket"
-    },
-    {
-        "name": "Rough Gem",
-        "image": "Rough Gem.webp",
-        "status": false,
-        "id": "j_rough_gem"
-    },
-    {
-        "name": "Runner",
-        "image": "Runner.webp",
-        "status": false,
-        "id": "j_runner"
-    },
-    {
-        "name": "Satellite",
-        "image": "Satellite.webp",
-        "status": false,
-        "id": "j_satellite"
-    },
-    {
-        "name": "Scary Face",
-        "image": "Scary Face.webp",
-        "status": false,
-        "id": "j_scary_face"
-    },
-    {
-        "name": "Scholar",
-        "image": "Scholar.webp",
-        "status": false,
-        "id": "j_scholar"
-    },
-    {
-        "name": "S\u00e9ance",
-        "image": "S\u00e9ance.webp",
-        "status": false,
-        "id": "j_seance"
-    },
-    {
-        "name": "Seeing Double",
-        "image": "Seeing Double.webp",
-        "status": false,
-        "id": "j_seeing_double"
-    },
-    {
-        "name": "Seltzer",
-        "image": "Seltzer.webp",
-        "status": false,
-        "id": "j_selzer"
-    },
-    {
-        "name": "Shoot the Moon",
-        "image": "Shoot the Moon.webp",
-        "status": false,
-        "id": "j_shoot_the_moon"
-    },
-    {
-        "name": "Shortcut",
-        "image": "Shortcut.webp",
-        "status": false,
-        "id": "j_shortcut"
-    },
-    {
-        "name": "Showman",
-        "image": "Showman.webp",
-        "status": false,
-        "id": "j_ring_master"
-    },
-    {
-        "name": "Sixth Sense",
-        "image": "Sixth Sense.webp",
-        "status": false,
-        "id": "j_sixth_sense"
-    },
-    {
-        "name": "Sly Joker",
-        "image": "Sly Joker.webp",
-        "status": false,
-        "id": "j_sly"
-    },
-    {
-        "name": "Smeared Joker",
-        "image": "Smeared Joker.webp",
-        "status": false,
-        "id": "j_smeared"
-    },
-    {
-        "name": "Smiley Face",
-        "image": "Smiley Face.webp",
-        "status": false,
-        "id": "j_smiley"
-    },
-    {
-        "name": "Sock and Buskin",
-        "image": "Sock and Buskin.webp",
-        "status": false,
-        "id": "j_sock_and_buskin"
-    },
-    {
-        "name": "Space Joker",
-        "image": "Space Joker.webp",
-        "status": false,
-        "id": "j_space"
-    },
-    {
-        "name": "Spare Trousers",
-        "image": "Spare Trousers.webp",
-        "status": false,
-        "id": "j_trousers"
-    },
-    {
-        "name": "Splash",
-        "image": "Splash.webp",
-        "status": false,
-        "id": "j_splash"
-    },
-    {
-        "name": "Square Joker",
-        "image": "Square Joker.webp",
-        "status": false,
-        "id": "j_square"
-    },
-    {
-        "name": "Steel Joker",
-        "image": "Steel Joker.webp",
-        "status": false,
-        "id": "j_steel_joker"
-    },
-    {
-        "name": "Stone Joker",
-        "image": "Stone Joker.webp",
-        "status": false,
-        "id": "j_stone"
-    },
-    {
-        "name": "Stuntman",
-        "image": "Stuntman.webp",
-        "status": false,
-        "id": "j_stuntman"
-    },
-    {
-        "name": "Supernova",
-        "image": "Supernova.webp",
-        "status": false,
-        "id": "j_supernova"
-    },
-    {
-        "name": "Superposition",
-        "image": "Superposition.webp",
-        "status": false,
-        "id": "j_superposition"
-    },
-    {
-        "name": "Swashbuckler",
-        "image": "Swashbuckler.webp",
-        "status": false,
-        "id": "j_swashbuckler"
-    },
-    {
-        "name": "The Duo",
-        "image": "The Duo.webp",
-        "status": false,
-        "id": "j_duo"
-    },
-    {
-        "name": "The Family",
-        "image": "The Family.webp",
-        "status": false,
-        "id": "j_family"
-    },
-    {
-        "name": "The Idol",
-        "image": "The Idol.webp",
-        "status": false,
-        "id": "j_idol"
-    },
-    {
-        "name": "The Order",
-        "image": "The Order.webp",
-        "status": false,
-        "id": "j_order"
-    },
-    {
-        "name": "The Tribe",
-        "image": "The Tribe.webp",
-        "status": false,
-        "id": "j_tribe"
-    },
-    {
-        "name": "The Trio",
-        "image": "The Trio.webp",
-        "status": false,
-        "id": "j_trio"
-    },
-    {
-        "name": "Throwback",
-        "image": "Throwback.webp",
-        "status": false,
-        "id": "j_throwback"
-    },
-    {
-        "name": "To Do List",
-        "image": "To Do List.webp",
-        "status": false,
-        "id": "j_todo_list"
-    },
-    {
-        "name": "To the Moon",
-        "image": "To the Moon.webp",
-        "status": false,
-        "id": "j_to_the_moon"
-    },
-    {
-        "name": "Trading Card",
-        "image": "Trading Card.webp",
-        "status": false,
-        "id": "j_trading"
-    },
-    {
-        "name": "Triboulet",
-        "image": "Triboulet.webp",
-        "status": false,
-        "id": "j_triboulet"
-    },
-    {
-        "name": "Troubadour",
-        "image": "Troubadour.webp",
-        "status": false,
-        "id": "j_troubadour"
-    },
-    {
-        "name": "Turtle Bean",
-        "image": "Turtle Bean.webp",
-        "status": false,
-        "id": "j_turtle_bean"
-    },
-    {
-        "name": "Vagabond",
-        "image": "Vagabond.webp",
-        "status": false,
-        "id": "j_vagabond"
-    },
-    {
-        "name": "Vampire",
-        "image": "Vampire.webp",
-        "status": false,
-        "id": "j_vampire"
-    },
-    {
-        "name": "Walkie Talkie",
-        "image": "Walkie Talkie.webp",
-        "status": false,
-        "id": "j_walkie_talkie"
-    },
-    {
-        "name": "Wee Joker",
-        "image": "Wee Joker.webp",
-        "status": false,
-        "id": "j_wee"
-    },
-    {
-        "name": "Wily Joker",
-        "image": "Wily Joker.webp",
-        "status": false,
-        "id": "j_wily"
-    },
-    {
-        "name": "Wrathful Joker",
-        "image": "Wrathful Joker.webp",
-        "status": false,
-        "id": "j_wrathful_joker"
-    },
-    {
-        "name": "Yorick",
-        "image": "Yorick.webp",
-        "status": false,
-        "id": "j_yorick"
-    },
-    {
-        "name": "Zany Joker",
-        "image": "Zany Joker.webp",
-        "status": false,
-        "id": "j_zany"
-    }
+  {
+    "name": "8 Ball",
+    "image": "8 Ball.webp",
+    "status": false,
+    "id": "j_8_ball",
+    "description": "<div class='joker-description'><span class='c-green'>1 in 4</span> chance for each<br>played <span class='c-attention'>8</span> to create a<br><span class='c-tarot'>Tarot</span> card when scored<br><span class='c-inactive'>(Must have room)</span></div>"
+  },
+  {
+    "name": "Abstract Joker",
+    "image": "Abstract Joker.webp",
+    "status": false,
+    "id": "j_abstract",
+    "description": "<div class='joker-description'><span class='c-mult'>+3</span> Mult for<br>each <span class='c-attention'>Joker</span> card<br><span class='c-inactive'>(Currently </span><span class='c-red'>+0</span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Acrobat",
+    "image": "Acrobat.webp",
+    "status": false,
+    "id": "j_acrobat",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3 </span> Mult on <span class='c-attention'>final</span><br><span class='c-attention'>hand</span> of round</div>"
+  },
+  {
+    "name": "Ancient Joker",
+    "image": "Ancient Joker.webp",
+    "status": false,
+    "id": "j_ancient",
+    "description": "<div class='joker-description'>Each played card with<br><span class='variable'>[random suit]</span> suit gives<br><span class='x-mult c-red c-white'> X1.5 </span> Mult when scored,<br><span class='size-0-8'>suit changes at end of round</span></div>"
+  },
+  {
+    "name": "Arrowhead",
+    "image": "Arrowhead.webp",
+    "status": false,
+    "id": "j_arrowhead",
+    "description": "<div class='joker-description'>Played cards with<br><span class='c-spades'>Spade</span> suit give<br><span class='c-chips'>+50</span> Chips when scored</div>"
+  },
+  {
+    "name": "Astronomer",
+    "image": "Astronomer.webp",
+    "status": false,
+    "id": "j_astronomer",
+    "description": "<div class='joker-description'>All <span class='c-planet'>Planet</span> cards and<br><span class='c-planet'>Celestial Packs</span> in<br>the shop are <span class='c-attention'>free</span></div>"
+  },
+  {
+    "name": "Banner",
+    "image": "Banner.webp",
+    "status": false,
+    "id": "j_banner",
+    "description": "<div class='joker-description'><span class='c-chips'>+30</span> Chips for<br>each remaining<br><span class='c-attention'>discard</span></div>"
+  },
+  {
+    "name": "Baron",
+    "image": "Baron.webp",
+    "status": false,
+    "id": "j_baron",
+    "description": "<div class='joker-description'>Each <span class='c-attention'>King</span><br>held in hand<br>gives <span class='x-mult c-red c-white'> X1.5 </span> Mult</div>"
+  },
+  {
+    "name": "Baseball Card",
+    "image": "Baseball Card.webp",
+    "status": false,
+    "id": "j_baseball",
+    "description": "<div class='joker-description'><span class='c-green'>Uncommon</span> Jokers<br>each give <span class='x-mult c-red c-white'> X1.5 </span> Mult</div>"
+  },
+  {
+    "name": "Blackboard",
+    "image": "Blackboard.webp",
+    "status": false,
+    "id": "j_blackboard",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3 </span> Mult if all<br>cards held in hand<br>are <span class='c-spades'>Spades</span> or <span class='c-clubs'>Clubs</span></div>"
+  },
+  {
+    "name": "Bloodstone",
+    "image": "Bloodstone.webp",
+    "status": false,
+    "id": "j_bloodstone",
+    "description": "<div class='joker-description'><span class='c-green'>1 in 2</span> chance for<br>played cards with<br><span class='c-hearts'>Heart</span> suit to give<br><span class='x-mult c-red c-white'> X1.5 </span> Mult when scored</div>"
+  },
+  {
+    "name": "Blue Joker",
+    "image": "Blue Joker.webp",
+    "status": false,
+    "id": "j_blue_joker",
+    "description": "<div class='joker-description'><span class='c-chips'>+2</span> Chips for each<br>remaining card in <span class='c-attention'>deck</span><br><span class='c-inactive'>(Currently </span><span class='c-chips'>+52</span><span class='c-inactive'> Chips)</span></div>"
+  },
+  {
+    "name": "Blueprint",
+    "image": "Blueprint.webp",
+    "status": false,
+    "id": "j_blueprint",
+    "description": "<div class='joker-description'>Copies ability of<br><span class='c-attention'>Joker</span> to the right</div>"
+  },
+  {
+    "name": "Bootstraps",
+    "image": "Bootstraps.webp",
+    "status": false,
+    "id": "j_bootstraps",
+    "description": "<div class='joker-description'><span class='c-mult'>+2</span> Mult for every<br><span class='c-money'>$5</span> you have<br><span class='c-inactive'>(Currently </span><span class='c-mult'>+0</span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Brainstorm",
+    "image": "Brainstorm.webp",
+    "status": false,
+    "id": "j_brainstorm",
+    "description": "<div class='joker-description'>Copies the ability<br>of leftmost <span class='c-attention'>Joker</span></div>"
+  },
+  {
+    "name": "Bull",
+    "image": "Bull.webp",
+    "status": false,
+    "id": "j_bull",
+    "description": "<div class='joker-description'><span class='c-chips'>+2</span> Chips for<br>each <span class='c-money'>$1</span> you have<br><span class='c-inactive'>(Currently </span><span class='c-chips'>+0</span><span class='c-inactive'> Chips)</span></div>"
+  },
+  {
+    "name": "Burglar",
+    "image": "Burglar.webp",
+    "status": false,
+    "id": "j_burglar",
+    "description": "<div class='joker-description'>When <span class='c-attention'>Blind</span> is selected,<br>gain <span class='c-blue'>+3</span> Hands and<br><span class='c-attention'>lose all discards</span></div>"
+  },
+  {
+    "name": "Burnt Joker",
+    "image": "Burnt Joker.webp",
+    "status": false,
+    "id": "j_burnt",
+    "description": "<div class='joker-description'>Upgrade the level of<br>the first <span class='c-attention'>discarded</span><br>poker hand each round</div>"
+  },
+  {
+    "name": "Business Card",
+    "image": "Business Card.webp",
+    "status": false,
+    "id": "j_business",
+    "description": "<div class='joker-description'>Played <span class='c-attention'>face</span> cards have<br>a <span class='c-green'>1 in 2</span> chance to<br>give <span class='c-money'>$2</span> when scored</div>"
+  },
+  {
+    "name": "Campfire",
+    "image": "Campfire.webp",
+    "status": false,
+    "id": "j_campfire",
+    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'>X0.25</span> Mult<br>for each card <span class='c-attention'>sold</span>, resets<br>when <span class='c-attention'>Boss Blind</span> is defeated<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Canio",
+    "image": "Canio.webp",
+    "status": false,
+    "id": "j_caino",
+    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X1 </span> Mult<br>when a <span class='c-attention'>face</span> card<br>is destroyed<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Card Sharp",
+    "image": "Card Sharp.webp",
+    "status": false,
+    "id": "j_card_sharp",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3.0 </span> Mult if played<br><span class='c-attention'>poker hand</span> has already<br>been played this round</div>"
+  },
+  {
+    "name": "Cartomancer",
+    "image": "Cartomancer.webp",
+    "status": false,
+    "id": "j_cartomancer",
+    "description": "<div class='joker-description'>Create a <span class='c-tarot'>Tarot</span> card<br>when <span class='c-attention'>Blind</span> is selected<br><span class='c-inactive'>(Must have room)</span></div>"
+  },
+  {
+    "name": "Castle",
+    "image": "Castle.webp",
+    "status": false,
+    "id": "j_castle",
+    "description": "<div class='joker-description'>This Joker gains <span class='c-chips'>+3</span> Chips<br>per discarded <span class='variable'>[random owned suit]</span> card,<br>suit changes every round<br><span class='c-inactive'>(Currently </span><span class='c-chips'>+0</span><span class='c-inactive'> Chips)</span></div>"
+  },
+  {
+    "name": "Cavendish",
+    "image": "Cavendish.webp",
+    "status": false,
+    "id": "j_cavendish",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3.0 </span> Mult<br><span class='c-green'>1 in 1000</span> chance this<br>card is destroyed<br>at end of round</div>"
+  },
+  {
+    "name": "Ceremonial Dagger",
+    "image": "Ceremonial Dagger.webp",
+    "status": false,
+    "id": "j_ceremonial",
+    "description": "<div class='joker-description'>When <span class='c-attention'>Blind</span> is selected,<br>destroy Joker to the right<br>and permanently add <span class='c-attention'>double</span><br>its sell value to this <span class='c-red'>Mult</span><br><span class='c-inactive'>(Currently </span><span class='c-mult'>+0</span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Certificate",
+    "image": "Certificate.webp",
+    "status": false,
+    "id": "j_certificate",
+    "description": "<div class='joker-description'>When round begins,<br>add a random <span class='c-attention'>playing</span><br><span class='c-attention'>card</span> with a random<br><span class='c-attention'>seal</span> to your hand</div>"
+  },
+  {
+    "name": "Chaos the Clown",
+    "image": "Chaos the Clown.webp",
+    "status": false,
+    "id": "j_chaos",
+    "description": "<div class='joker-description'><span class='c-attention'>1</span> free <span class='c-green'>Reroll</span><br>per shop</div>"
+  },
+  {
+    "name": "Chicot",
+    "image": "Chicot.webp",
+    "status": false,
+    "id": "j_chicot",
+    "description": "<div class='joker-description'>Disables effect of<br>every <span class='c-attention'>Boss Blind</span></div>"
+  },
+  {
+    "name": "Clever Joker",
+    "image": "Clever Joker.webp",
+    "status": false,
+    "id": "j_clever",
+    "description": "<div class='joker-description'><span class='c-chips'>+80</span> Chips if played<br>hand contains<br>a <span class='c-attention'>Two Pair</span></div>"
+  },
+  {
+    "name": "Cloud 9",
+    "image": "Cloud 9.webp",
+    "status": false,
+    "id": "j_cloud_9",
+    "description": "<div class='joker-description'>Earn <span class='c-money'>$1</span> for each<br><span class='c-attention'>9</span> in your <span class='c-attention'>full deck</span><br>at end of round<br><span class='c-inactive'>(Currently <span class='c-money'>$4</span></span><span class='c-inactive'>)</span></div>"
+  },
+  {
+    "name": "Constellation",
+    "image": "Constellation.webp",
+    "status": false,
+    "id": "j_constellation",
+    "description": "<div class='joker-description'>This Joker gains<br><span class='x-mult c-red c-white'> X0.1 </span> Mult every time<br>a <span class='c-planet'>Planet</span> card is used<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Crafty Joker",
+    "image": "Crafty Joker.webp",
+    "status": false,
+    "id": "j_crafty",
+    "description": "<div class='joker-description'><span class='c-chips'>+80</span> Chips if played<br>hand contains<br>a <span class='c-attention'>Flush</span></div>"
+  },
+  {
+    "name": "Crazy Joker",
+    "image": "Crazy Joker.webp",
+    "status": false,
+    "id": "j_crazy",
+    "description": "<div class='joker-description'><span class='c-red'>+12</span> Mult if played<br>hand contains<br>a <span class='c-attention'>Straight</span></div>"
+  },
+  {
+    "name": "Credit Card",
+    "image": "Credit Card.webp",
+    "status": false,
+    "id": "j_credit_card",
+    "description": "<div class='joker-description'>Go up to<br><span class='c-red'>-$20</span> in debt</div>"
+  },
+  {
+    "name": "Delayed Gratification",
+    "image": "Delayed Gratification.webp",
+    "status": false,
+    "id": "j_delayed_grat",
+    "description": "<div class='joker-description'>Earn <span class='c-money'>$2</span> per <span class='c-attention'>discard</span> if<br>no discards are used<br>by end of the round</div>"
+  },
+  {
+    "name": "Devious Joker",
+    "image": "Devious Joker.webp",
+    "status": false,
+    "id": "j_devious",
+    "description": "<div class='joker-description'><span class='c-chips'>+100</span> Chips if played<br>hand contains<br>a <span class='c-attention'>Straight</span></div>"
+  },
+  {
+    "name": "Diet Cola",
+    "image": "Diet Cola.webp",
+    "status": false,
+    "id": "j_diet_cola",
+    "description": "<div class='joker-description'>Sell this card to<br>create a free<br><span class='c-attention'>Double Tag</span></div>"
+  },
+  {
+    "name": "DNA",
+    "image": "DNA.webp",
+    "status": false,
+    "id": "j_dna",
+    "description": "<div class='joker-description'>If <span class='c-attention'>first hand</span> of round<br>has only <span class='c-attention'>1</span> card, add a<br>permanent copy to deck<br>and draw it to <span class='c-attention'>hand</span></div>"
+  },
+  {
+    "name": "Driver's License",
+    "image": "Driver's License.webp",
+    "status": false,
+    "id": "j_drivers_license",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X#1# </span> Mult if you have<br>at least <span class='c-attention'>16</span> Enhanced<br>cards in your full deck<br><span class='c-inactive'>(Currently </span><span class='c-attention'>#2#</span><span class='c-inactive'>)</span></div>"
+  },
+  {
+    "name": "Droll Joker",
+    "image": "Droll Joker.webp",
+    "status": false,
+    "id": "j_droll",
+    "description": "<div class='joker-description'><span class='c-red'>+10</span> Mult if played<br>hand contains<br>a <span class='c-attention'>Flush</span></div>"
+  },
+  {
+    "name": "Drunkard",
+    "image": "Drunkard.webp",
+    "status": false,
+    "id": "j_drunkard",
+    "description": "<div class='joker-description'><span class='c-red'>+1</span> discard<br>each round</div>"
+  },
+  {
+    "name": "Dusk",
+    "image": "Dusk.webp",
+    "status": false,
+    "id": "j_dusk",
+    "description": "<div class='joker-description'>Retrigger all played<br>cards in <span class='c-attention'>final</span><br><span class='c-attention'>hand</span> of round</div>"
+  },
+  {
+    "name": "Egg",
+    "image": "Egg.webp",
+    "status": false,
+    "id": "j_egg",
+    "description": "<div class='joker-description'>Gains <span class='c-money'>$3</span> of<br><span class='c-attention'>sell value</span> at<br>end of round</div>"
+  },
+  {
+    "name": "Erosion",
+    "image": "Erosion.webp",
+    "status": false,
+    "id": "j_erosion",
+    "description": "<div class='joker-description'><span class='c-red'>+4</span> Mult for each<br>card below <span class='c-attention'>52</span><br>in your full deck<br><span class='c-inactive'>(Currently </span><span class='c-red'>+0</span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Even Steven",
+    "image": "Even Steven.webp",
+    "status": false,
+    "id": "j_even_steven",
+    "description": "<div class='joker-description'>Played cards with<br><span class='c-attention'>even</span> rank give<br><span class='c-mult'>+4</span> Mult when scored<br><span class='c-inactive'>(10, 8, 6, 4, 2)</span></div>"
+  },
+  {
+    "name": "Faceless Joker",
+    "image": "Faceless Joker.webp",
+    "status": false,
+    "id": "j_faceless",
+    "description": "<div class='joker-description'>Earn <span class='c-money'>$5</span> if <span class='c-attention'>3</span> or<br>more <span class='c-attention'>face cards</span><br>are discarded<br>at the same time</div>"
+  },
+  {
+    "name": "Fibonacci",
+    "image": "Fibonacci.webp",
+    "status": false,
+    "id": "j_fibonacci",
+    "description": "<div class='joker-description'>Each played <span class='c-attention'>Ace</span>,<br><span class='c-attention'>2</span>, <span class='c-attention'>3</span>, <span class='c-attention'>5</span>, or <span class='c-attention'>8</span> gives<br><span class='c-mult'>+8</span> Mult when scored</div>"
+  },
+  {
+    "name": "Flash Card",
+    "image": "Flash Card.webp",
+    "status": false,
+    "id": "j_flash",
+    "description": "<div class='joker-description'>This Joker gains <span class='c-mult'>+2</span> Mult<br>per <span class='c-attention'>reroll</span> in the shop<br><span class='c-inactive'>(Currently </span><span class='c-mult'>+0</span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Flower Pot",
+    "image": "Flower Pot.webp",
+    "status": false,
+    "id": "j_flower_pot",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3 </span> Mult if poker<br>hand contains a<br><span class='c-diamonds'>Diamond</span> card, <span class='c-clubs'>Club</span> card,<br><span class='c-hearts'>Heart</span> card, and <span class='c-spades'>Spade</span> card</div>"
+  },
+  {
+    "name": "Fortune Teller",
+    "image": "Fortune Teller.webp",
+    "status": false,
+    "id": "j_fortune_teller",
+    "description": "<div class='joker-description'><span class='c-red'>+1</span> Mult per <span class='c-purple'>Tarot</span><br>card used this run<br><span class='c-inactive'>(Currently </span><span class='c-red'>+0</span><span class='c-inactive'>)</span></div>"
+  },
+  {
+    "name": "Four Fingers",
+    "image": "Four Fingers.webp",
+    "status": false,
+    "id": "j_four_fingers",
+    "description": "<div class='joker-description'>All <span class='c-attention'>Flushes</span> and<br><span class='c-attention'>Straights</span> can be<br>made with <span class='c-attention'>4</span> cards</div>"
+  },
+  {
+    "name": "Gift Card",
+    "image": "Gift Card.webp",
+    "status": false,
+    "id": "j_gift",
+    "description": "<div class='joker-description'>Add <span class='c-money'>$1</span> of <span class='c-attention'>sell value</span><br>to every <span class='c-attention'>Joker</span> and<br><span class='c-attention'>Consumable</span> card at<br>end of round</div>"
+  },
+  {
+    "name": "Glass Joker",
+    "image": "Glass Joker.webp",
+    "status": false,
+    "id": "j_glass",
+    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.75 </span> Mult<br>for every <span class='c-attention'>Glass Card</span><br>that is destroyed<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Gluttonous Joker",
+    "image": "Gluttonous Joker.webp",
+    "status": false,
+    "id": "j_gluttenous_joker",
+    "description": "<div class='joker-description'>Played cards with<br><span class='c-clubs'>Clubs</span> suit give<br><span class='c-mult'>+3</span> Mult when scored</div>"
+  },
+  {
+    "name": "Golden Joker",
+    "image": "Golden Joker.webp",
+    "status": false,
+    "id": "j_golden",
+    "description": "<div class='joker-description'>Earn <span class='c-money'>$4</span> at<br>end of round</div>"
+  },
+  {
+    "name": "Golden Ticket",
+    "image": "Golden Ticket.webp",
+    "status": false,
+    "id": "j_ticket",
+    "description": "<div class='joker-description'>Played <span class='c-attention'>Gold</span> cards<br>earn <span class='c-money'>$4</span> when scored</div>"
+  },
+  {
+    "name": "Greedy Joker",
+    "image": "Greedy Joker.webp",
+    "status": false,
+    "id": "j_greedy_joker",
+    "description": "<div class='joker-description'>Played cards with<br><span class='c-diamonds'>Diamonds</span> suit give<br><span class='c-mult'>+3</span> Mult when scored</div>"
+  },
+  {
+    "name": "Green Joker",
+    "image": "Green Joker.webp",
+    "status": false,
+    "id": "j_green_joker",
+    "description": "<div class='joker-description'><span class='c-mult'>+1</span> Mult per hand played<br><span class='c-mult'>-1</span> Mult per discard<br><span class='c-inactive'>(Currently </span><span class='c-mult'>+0</span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Gros Michel",
+    "image": "Gros Michel.webp",
+    "status": false,
+    "id": "j_gros_michel",
+    "description": "<div class='joker-description'><span class='c-mult'>+15</span> Mult<br><span class='c-green'>1 in 6</span> chance this<br>card is destroyed<br>at end of round</div>"
+  },
+  {
+    "name": "Hack",
+    "image": "Hack.webp",
+    "status": false,
+    "id": "j_hack",
+    "description": "<div class='joker-description'>Retrigger<br>each played<br><span class='c-attention'>2</span>, <span class='c-attention'>3</span>, <span class='c-attention'>4</span>, or <span class='c-attention'>5</span></div>"
+  },
+  {
+    "name": "Half Joker",
+    "image": "Half Joker.webp",
+    "status": false,
+    "id": "j_half",
+    "description": "<div class='joker-description'><span class='c-red'>+20</span> Mult if played<br>hand contains<br><span class='c-attention'>3</span> or fewer cards</div>"
+  },
+  {
+    "name": "Hallucination",
+    "image": "Hallucination.webp",
+    "status": false,
+    "id": "j_hallucination",
+    "description": "<div class='joker-description'><span class='c-green'>1 in 2</span> chance to create<br>a <span class='c-tarot'>Tarot</span> card when any<br><span class='c-attention'>Booster Pack</span> is opened<br><span class='c-inactive'>(Must have room)</span></div>"
+  },
+  {
+    "name": "Hanging Chad",
+    "image": "Hanging Chad.webp",
+    "status": false,
+    "id": "j_hanging_chad",
+    "description": "<div class='joker-description'>Retrigger <span class='c-attention'>first</span> played<br>card used in scoring<br><span class='c-attention'>2</span> additional times</div>"
+  },
+  {
+    "name": "Hiker",
+    "image": "Hiker.webp",
+    "status": false,
+    "id": "j_hiker",
+    "description": "<div class='joker-description'>Every played <span class='c-attention'>card</span><br>permanently gains<br><span class='c-chips'>+5</span> Chips when scored</div>"
+  },
+  {
+    "name": "Hit the Road",
+    "image": "Hit the Road.webp",
+    "status": false,
+    "id": "j_hit_the_road",
+    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.5 </span> Mult<br>for every <span class='c-attention'>Jack</span><br>discarded this round<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Hologram",
+    "image": "Hologram.webp",
+    "status": false,
+    "id": "j_hologram",
+    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.25 </span> Mult<br>every time a <span class='c-attention'>playing card</span><br>is added to your deck<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Ice Cream",
+    "image": "Ice Cream.webp",
+    "status": false,
+    "id": "j_ice_cream",
+    "description": "<div class='joker-description'><span class='c-chips'>+100</span> Chips<br><span class='c-chips'>-5</span> Chips for<br>every hand played</div>"
+  },
+  {
+    "name": "Invisible Joker",
+    "image": "Invisible Joker.webp",
+    "status": false,
+    "id": "j_invisible",
+    "description": "<div class='joker-description'>After <span class='c-attention'>2</span> rounds,<br>sell this card to<br><span class='c-attention'>Duplicate</span> a random Joker<br><span class='c-inactive'>(Currently </span><span class='c-attention'>0</span><span class='c-inactive'>/2)</span></div>"
+  },
+  {
+    "name": "Joker",
+    "image": "Joker.webp",
+    "status": false,
+    "id": "j_joker",
+    "description": "<div class='joker-description'><span class='c-red'>+4</span> Mult</div>"
+  },
+  {
+    "name": "Joker Stencil",
+    "image": "Joker Stencil.webp",
+    "status": false,
+    "id": "j_stencil",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X1 </span> Mult for each<br>empty <span class='c-attention'>Joker</span> slot<br><span class='size-0-8'>Joker Stencil included</span><br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'>)</span></div>"
+  },
+  {
+    "name": "Jolly Joker",
+    "image": "Jolly Joker.webp",
+    "status": false,
+    "id": "j_jolly",
+    "description": "<div class='joker-description'><span class='c-red'>+8</span> Mult if played<br>hand contains<br>a <span class='c-attention'>Pair</span></div>"
+  },
+  {
+    "name": "Juggler",
+    "image": "Juggler.webp",
+    "status": false,
+    "id": "j_juggler",
+    "description": "<div class='joker-description'><span class='c-attention'>+1</span> hand size</div>"
+  },
+  {
+    "name": "Loyalty Card",
+    "image": "Loyalty Card.webp",
+    "status": false,
+    "id": "j_loyalty_card",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X4.0 </span> Mult every<br><span class='c-attention'>6</span> hands played<br><span class='c-inactive'></span></div>"
+  },
+  {
+    "name": "Luchador",
+    "image": "Luchador.webp",
+    "status": false,
+    "id": "j_luchador",
+    "description": "<div class='joker-description'>Sell this card to<br>disable the current<br><span class='c-attention'>Boss Blind</span></div>"
+  },
+  {
+    "name": "Lucky Cat",
+    "image": "Lucky Cat.webp",
+    "status": false,
+    "id": "j_lucky_cat",
+    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.25 </span> Mult<br>every time a <span class='c-attention'>Lucky</span> card<br><span class='c-green'>successfully</span> triggers<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Lusty Joker",
+    "image": "Lusty Joker.webp",
+    "status": false,
+    "id": "j_lusty_joker",
+    "description": "<div class='joker-description'>Played cards with<br><span class='c-hearts'>Hearts</span> suit give<br><span class='c-mult'>+3</span> Mult when scored</div>"
+  },
+  {
+    "name": "Mad Joker",
+    "image": "Mad Joker.webp",
+    "status": false,
+    "id": "j_mad",
+    "description": "<div class='joker-description'><span class='c-red'>+10</span> Mult if played<br>hand contains<br>a <span class='c-attention'>Two Pair</span></div>"
+  },
+  {
+    "name": "Madness",
+    "image": "Madness.webp",
+    "status": false,
+    "id": "j_madness",
+    "description": "<div class='joker-description'>When <span class='c-attention'>Small Blind</span> or <span class='c-attention'>Big Blind</span><br>is selected, gain <span class='x-mult c-red c-white'> X0.5 </span> Mult<br>and <span class='c-attention'>destroy</span> a random Joker<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Mail-In Rebate",
+    "image": "Mail-In Rebate.webp",
+    "status": false,
+    "id": "j_mail",
+    "description": "<div class='joker-description'>Earn <span class='c-money'>$5</span> for each<br>discarded <span class='c-attention'>2</span>, rank<br>changes every round</div>"
+  },
+  {
+    "name": "Marble Joker",
+    "image": "Marble Joker.webp",
+    "status": false,
+    "id": "j_marble",
+    "description": "<div class='joker-description'>Adds one <span class='c-attention'>Stone</span> card<br>to deck when<br><span class='c-attention'>Blind</span> is selected</div>"
+  },
+  {
+    "name": "Matador",
+    "image": "Matador.webp",
+    "status": false,
+    "id": "j_matador",
+    "description": "<div class='joker-description'>Earn <span class='c-money'>$8</span> if played<br>hand triggers the<br><span class='c-attention'>Boss Blind</span> ability</div>"
+  },
+  {
+    "name": "Merry Andy",
+    "image": "Merry Andy.webp",
+    "status": false,
+    "id": "j_merry_andy",
+    "description": "<div class='joker-description'><span class='c-red'>+3</span> discards<br>each round,<br><span class='c-red'>-1</span> hand size</div>"
+  },
+  {
+    "name": "Midas Mask",
+    "image": "Midas Mask.webp",
+    "status": false,
+    "id": "j_midas_mask",
+    "description": "<div class='joker-description'>All played <span class='c-attention'>face</span> cards<br>become <span class='c-attention'>Gold</span> cards<br>when scored</div>"
+  },
+  {
+    "name": "Mime",
+    "image": "Mime.webp",
+    "status": false,
+    "id": "j_mime",
+    "description": "<div class='joker-description'>Retrigger all<br>card <span class='c-attention'>held in</span><br><span class='c-attention'>hand</span> abilities</div>"
+  },
+  {
+    "name": "Misprint",
+    "image": "Misprint.webp",
+    "status": false,
+    "id": "j_misprint",
+    "description": "<div class='joker-description'><span class='c-mult'>+[0 to 23]</span> Mult</div>"
+  },
+  {
+    "name": "Mr. Bones",
+    "image": "Mr. Bones.webp",
+    "status": false,
+    "id": "j_mr_bones",
+    "description": "<div class='joker-description'>Prevents Death<br>if chips scored<br>are at least <span class='c-attention'>25%</span><br>of required chips<br><span class='size-1-1 c-red enhanced-text'>self destructs</span></div>"
+  },
+  {
+    "name": "Mystic Summit",
+    "image": "Mystic Summit.webp",
+    "status": false,
+    "id": "j_mystic_summit",
+    "description": "<div class='joker-description'><span class='c-mult'>+15</span> Mult when<br><span class='c-attention'>0</span> discards<br>remaining</div>"
+  },
+  {
+    "name": "Obelisk",
+    "image": "Obelisk.webp",
+    "status": false,
+    "id": "j_obelisk",
+    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.2 </span> Mult<br>per <span class='c-attention'>consecutive</span> hand played<br>without playing your<br>most played <span class='c-attention'>poker hand</span><br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Odd Todd",
+    "image": "Odd Todd.webp",
+    "status": false,
+    "id": "j_odd_todd",
+    "description": "<div class='joker-description'>Played cards with<br><span class='c-attention'>odd</span> rank give<br><span class='c-chips'>+31</span> Chips when scored<br><span class='c-inactive'>(A, 9, 7, 5, 3)</span></div>"
+  },
+  {
+    "name": "Onyx Agate",
+    "image": "Onyx Agate.webp",
+    "status": false,
+    "id": "j_onyx_agate",
+    "description": "<div class='joker-description'>Played cards with<br><span class='c-clubs'>Club</span> suit give<br><span class='c-mult'>+7</span> Mult when scored</div>"
+  },
+  {
+    "name": "Oops! All 6s",
+    "image": "Oops! All 6s.webp",
+    "status": false,
+    "id": "j_oops",
+    "description": "<div class='joker-description'>Doubles all <span class='c-attention'>listed</span><br><span class='c-green c-e:1 c-s:1.1'>probabilities</span><br><span class='c-inactive'>(ex: </span><span class='c-green'>1 in 3</span><span class='c-inactive'> -> </span><span class='c-green'>2 in 3</span><span class='c-inactive'>)</span></div>"
+  },
+  {
+    "name": "Pareidolia",
+    "image": "Pareidolia.webp",
+    "status": false,
+    "id": "j_pareidolia",
+    "description": "<div class='joker-description'>All cards are<br>considered<br><span class='c-attention'>face</span> cards</div>"
+  },
+  {
+    "name": "Perkeo",
+    "image": "Perkeo.webp",
+    "status": false,
+    "id": "j_perkeo",
+    "description": "<div class='joker-description'>Creates a <span class='c-dark-edition'>Negative</span> copy of<br><span class='c-attention'>1</span> random <span class='c-attention'>consumable</span><br>card in your possession<br>at the end of the <span class='c-attention'>shop</span></div>"
+  },
+  {
+    "name": "Photograph",
+    "image": "Photograph.webp",
+    "status": false,
+    "id": "j_photograph",
+    "description": "<div class='joker-description'>First played <span class='c-attention'>face</span><br>card gives <span class='x-mult c-red c-white'> X2 </span> Mult<br>when scored</div>"
+  },
+  {
+    "name": "Popcorn",
+    "image": "Popcorn.webp",
+    "status": false,
+    "id": "j_popcorn",
+    "description": "<div class='joker-description'><span class='c-mult'>+20</span> Mult<br><span class='c-mult'>-4</span> Mult per<br>round played</div>"
+  },
+  {
+    "name": "Raised Fist",
+    "image": "Raised Fist.webp",
+    "status": false,
+    "id": "j_raised_fist",
+    "description": "<div class='joker-description'>Adds <span class='c-attention'>double</span> the rank<br>of <span class='c-attention'>lowest</span> ranked card<br>held in hand to Mult</div>"
+  },
+  {
+    "name": "Ramen",
+    "image": "Ramen.webp",
+    "status": false,
+    "id": "j_ramen",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X2 </span> Mult,<br>loses <span class='x-mult c-red c-white'> X0.01 </span> Mult<br>per <span class='c-attention'>card</span> discarded</div>"
+  },
+  {
+    "name": "Red Card",
+    "image": "Red Card.webp",
+    "status": false,
+    "id": "j_red_card",
+    "description": "<div class='joker-description'>This Joker gains<br><span class='c-red'>+3</span> Mult when any<br><span class='c-attention'>Booster Pack</span> is skipped<br><span class='c-inactive'>(Currently </span><span class='c-red'>+0</span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Reserved Parking",
+    "image": "Reserved Parking.webp",
+    "status": false,
+    "id": "j_reserved_parking",
+    "description": "<div class='joker-description'>Each <span class='c-attention'>face</span> card<br>held in hand has<br>a <span class='c-green'>1 in 2</span> chance<br>to give <span class='c-money'>$1</span></div>"
+  },
+  {
+    "name": "Ride the Bus",
+    "image": "Ride the Bus.webp",
+    "status": false,
+    "id": "j_ride_the_bus",
+    "description": "<div class='joker-description'>This Joker gains <span class='c-mult'>+1</span> Mult<br>per <span class='c-attention'>consecutive</span> hand<br>played without a<br>scoring <span class='c-attention'>face</span> card<br><span class='c-inactive'>(Currently </span><span class='c-mult'>+0</span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Riff-Raff",
+    "image": "Riff-Raff.webp",
+    "status": false,
+    "id": "j_riff_raff",
+    "description": "<div class='joker-description'>When <span class='c-attention'>Blind</span> is selected,<br>create <span class='c-attention'>2 </span><span class='c-blue'>Common</span><span class='c-attention'> Jokers</span><br><span class='c-inactive'>(Must have room)</span></div>"
+  },
+  {
+    "name": "Rocket",
+    "image": "Rocket.webp",
+    "status": false,
+    "id": "j_rocket",
+    "description": "<div class='joker-description'>Earn <span class='c-money'>$1</span> at end of round<br>Payout increases by <span class='c-money'>$2</span><br>when <span class='c-attention'>Boss Blind</span> is defeated</div>"
+  },
+  {
+    "name": "Rough Gem",
+    "image": "Rough Gem.webp",
+    "status": false,
+    "id": "j_rough_gem",
+    "description": "<div class='joker-description'>Played cards with<br><span class='c-diamonds'>Diamond</span> suit earn<br><span class='c-money'>$1</span> when scored</div>"
+  },
+  {
+    "name": "Runner",
+    "image": "Runner.webp",
+    "status": false,
+    "id": "j_runner",
+    "description": "<div class='joker-description'>Gains <span class='c-chips'>+15</span> Chips<br>if played hand<br>contains a <span class='c-attention'>Straight</span><br><span class='c-inactive'>(Currently </span><span class='c-chips'>+0</span><span class='c-inactive'> Chips)</span></div>"
+  },
+  {
+    "name": "Satellite",
+    "image": "Satellite.webp",
+    "status": false,
+    "id": "j_satellite",
+    "description": "<div class='joker-description'>Earn <span class='c-money'>$1</span> at end of<br>round per unique <span class='c-planet'>Planet</span><br>card used this run<br><span class='c-inactive'>(Currently </span><span class='c-money'>$0</span><span class='c-inactive'>)</span></div>"
+  },
+  {
+    "name": "Scary Face",
+    "image": "Scary Face.webp",
+    "status": false,
+    "id": "j_scary_face",
+    "description": "<div class='joker-description'>Played <span class='c-attention'>face</span> cards<br>give <span class='c-chips'>+30</span> Chips<br>when scored</div>"
+  },
+  {
+    "name": "Scholar",
+    "image": "Scholar.webp",
+    "status": false,
+    "id": "j_scholar",
+    "description": "<div class='joker-description'>Played <span class='c-attention'>Aces</span><br>give <span class='c-chips'>+20</span> Chips<br>and <span class='c-mult'>+4</span> Mult<br>when scored</div>"
+  },
+  {
+    "name": "S\u00e9ance",
+    "image": "S\u00e9ance.webp",
+    "status": false,
+    "id": "j_seance",
+    "description": "<div class='joker-description'>If <span class='c-attention'>poker hand</span> is a<br><span class='c-attention'>Straight Flush</span>, create a<br>random <span class='c-spectral'>Spectral</span> card<br><span class='c-inactive'>(Must have room)</span></div>"
+  },
+  {
+    "name": "Seeing Double",
+    "image": "Seeing Double.webp",
+    "status": false,
+    "id": "j_seeing_double",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X2 </span> Mult if played<br>hand has a scoring<br><span class='c-clubs'>Club</span> card and a scoring<br>card of any other <span class='c-attention'>suit</span></div>"
+  },
+  {
+    "name": "Seltzer",
+    "image": "Seltzer.webp",
+    "status": false,
+    "id": "j_selzer",
+    "description": "<div class='joker-description'>Retrigger all<br>cards played for<br>the next <span class='c-attention'>10</span> hands</div>"
+  },
+  {
+    "name": "Shoot the Moon",
+    "image": "Shoot the Moon.webp",
+    "status": false,
+    "id": "j_shoot_the_moon",
+    "description": "<div class='joker-description'>Each <span class='c-attention'>Queen</span><br>held in hand<br>gives <span class='c-mult'>+13</span> Mult</div>"
+  },
+  {
+    "name": "Shortcut",
+    "image": "Shortcut.webp",
+    "status": false,
+    "id": "j_shortcut",
+    "description": "<div class='joker-description'>Allows <span class='c-attention'>Straights</span> to be<br>made with gaps of <span class='c-attention'>1 rank</span><br><span class='c-inactive'>(ex: </span><span class='c-attention'>10 8 6 5 3</span><span class='c-inactive'>)</span></div>"
+  },
+  {
+    "name": "Showman",
+    "image": "Showman.webp",
+    "status": false,
+    "id": "j_ring_master",
+    "description": "<div class='joker-description'><span class='c-attention'>Joker</span>, <span class='c-tarot'>Tarot</span>, <span class='c-planet'>Planet</span>,<br>and <span class='c-spectral'>Spectral</span> cards may<br>appear multiple times</div>"
+  },
+  {
+    "name": "Sixth Sense",
+    "image": "Sixth Sense.webp",
+    "status": false,
+    "id": "j_sixth_sense",
+    "description": "<div class='joker-description'>If <span class='c-attention'>first hand</span> of round is<br>a single <span class='c-attention'>6</span>, destroy it and<br>create a <span class='c-spectral'>Spectral</span> card<br><span class='c-inactive'>(Must have room)</span></div>"
+  },
+  {
+    "name": "Sly Joker",
+    "image": "Sly Joker.webp",
+    "status": false,
+    "id": "j_sly",
+    "description": "<div class='joker-description'><span class='c-chips'>+50</span> Chips if played<br>hand contains<br>a <span class='c-attention'>Pair</span></div>"
+  },
+  {
+    "name": "Smeared Joker",
+    "image": "Smeared Joker.webp",
+    "status": false,
+    "id": "j_smeared",
+    "description": "<div class='joker-description'><span class='c-hearts'>Hearts</span> and <span class='c-diamonds'>Diamonds</span><br>count as the same suit,<br><span class='c-spades'>Spades</span> and <span class='c-clubs'>Clubs</span><br>count as the same suit</div>"
+  },
+  {
+    "name": "Smiley Face",
+    "image": "Smiley Face.webp",
+    "status": false,
+    "id": "j_smiley",
+    "description": "<div class='joker-description'>Played <span class='c-attention'>face</span> cards<br>give <span class='c-mult'>+5</span> Mult<br>when scored</div>"
+  },
+  {
+    "name": "Sock and Buskin",
+    "image": "Sock and Buskin.webp",
+    "status": false,
+    "id": "j_sock_and_buskin",
+    "description": "<div class='joker-description'>Retrigger all<br>played <span class='c-attention'>face</span> cards</div>"
+  },
+  {
+    "name": "Space Joker",
+    "image": "Space Joker.webp",
+    "status": false,
+    "id": "j_space",
+    "description": "<div class='joker-description'><span class='c-green'>1 in 4</span> chance to<br>upgrade level of<br>played <span class='c-attention'>poker hand</span></div>"
+  },
+  {
+    "name": "Spare Trousers",
+    "image": "Spare Trousers.webp",
+    "status": false,
+    "id": "j_trousers",
+    "description": "<div class='joker-description'>This Joker gains <span class='c-mult'>+2</span> Mult<br>if played hand contains<br>a <span class='c-attention'>Two Pair</span><br><span class='c-inactive'>(Currently </span><span class='c-red'>+0</span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Splash",
+    "image": "Splash.webp",
+    "status": false,
+    "id": "j_splash",
+    "description": "<div class='joker-description'>Every <span class='c-attention'>played card</span><br>counts in scoring</div>"
+  },
+  {
+    "name": "Square Joker",
+    "image": "Square Joker.webp",
+    "status": false,
+    "id": "j_square",
+    "description": "<div class='joker-description'>This Joker gains <span class='c-chips'>+4</span> Chips<br>if played hand has<br>exactly <span class='c-attention'>4</span> cards<br><span class='c-inactive'>(Currently </span><span class='c-chips'>0</span><span class='c-inactive'> Chips)</span></div>"
+  },
+  {
+    "name": "Steel Joker",
+    "image": "Steel Joker.webp",
+    "status": false,
+    "id": "j_steel_joker",
+    "description": "<div class='joker-description'>Gives <span class='x-mult c-red c-white'> X0.2 </span> Mult<br>for each <span class='c-attention'>Steel Card</span><br>in your <span class='c-attention'>full deck</span><br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Stone Joker",
+    "image": "Stone Joker.webp",
+    "status": false,
+    "id": "j_stone",
+    "description": "<div class='joker-description'>Gives <span class='c-chips'>+25</span> Chips for<br>each <span class='c-attention'>Stone Card</span><br>in your <span class='c-attention'>full deck</span><br><span class='c-inactive'>(Currently </span><span class='c-chips'>+0</span><span class='c-inactive'> Chips)</span></div>"
+  },
+  {
+    "name": "Stuntman",
+    "image": "Stuntman.webp",
+    "status": false,
+    "id": "j_stuntman",
+    "description": "<div class='joker-description'><span class='c-chips'>+250</span> Chips,<br><span class='c-attention'>-2</span> hand size</div>"
+  },
+  {
+    "name": "Supernova",
+    "image": "Supernova.webp",
+    "status": false,
+    "id": "j_supernova",
+    "description": "<div class='joker-description'>Adds the number of times<br><span class='c-attention'>poker hand</span> has been<br>played this run to Mult</div>"
+  },
+  {
+    "name": "Superposition",
+    "image": "Superposition.webp",
+    "status": false,
+    "id": "j_superposition",
+    "description": "<div class='joker-description'>Create a <span class='c-tarot'>Tarot</span> card if<br>poker hand contains an<br><span class='c-attention'>Ace</span> and a <span class='c-attention'>Straight</span><br><span class='c-inactive'>(Must have room)</span></div>"
+  },
+  {
+    "name": "Swashbuckler",
+    "image": "Swashbuckler.webp",
+    "status": false,
+    "id": "j_swashbuckler",
+    "description": "<div class='joker-description'>Adds the sell value<br>of all other owned<br><span class='c-attention'>Jokers</span> to Mult<br><span class='c-inactive'>(Currently </span><span class='c-mult'>+1</span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "The Duo",
+    "image": "The Duo.webp",
+    "status": false,
+    "id": "j_duo",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X2 </span> Mult if played<br>hand contains<br>a <span class='c-attention'>Pair</span></div>"
+  },
+  {
+    "name": "The Family",
+    "image": "The Family.webp",
+    "status": false,
+    "id": "j_family",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X4 </span> Mult if played<br>hand contains<br>a <span class='c-attention'>Four of a Kind</span></div>"
+  },
+  {
+    "name": "The Idol",
+    "image": "The Idol.webp",
+    "status": false,
+    "id": "j_idol",
+    "description": "<div class='joker-description'>Each played <span class='c-attention'>[random owned card rank]</span><br>of <span class='variable'>[random owned card suit]</span> gives<br><span class='x-mult c-red c-white'> X2 </span> Mult when scored<br><span class='size-0-8'>Card changes every round</span></div>"
+  },
+  {
+    "name": "The Order",
+    "image": "The Order.webp",
+    "status": false,
+    "id": "j_order",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3 </span> Mult if played<br>hand contains<br>a <span class='c-attention'>Straight</span></div>"
+  },
+  {
+    "name": "The Tribe",
+    "image": "The Tribe.webp",
+    "status": false,
+    "id": "j_tribe",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X2 </span> Mult if played<br>hand contains<br>a <span class='c-attention'>Flush</span></div>"
+  },
+  {
+    "name": "The Trio",
+    "image": "The Trio.webp",
+    "status": false,
+    "id": "j_trio",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X3 </span> Mult if played<br>hand contains<br>a <span class='c-attention'>Three of a Kind</span></div>"
+  },
+  {
+    "name": "Throwback",
+    "image": "Throwback.webp",
+    "status": false,
+    "id": "j_throwback",
+    "description": "<div class='joker-description'><span class='x-mult c-red c-white'> X0.25 </span> Mult for each<br><span class='c-attention'>Blind</span> skipped this run<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "To Do List",
+    "image": "To Do List.webp",
+    "status": false,
+    "id": "j_todo_list",
+    "description": "<div class='joker-description'>Earn <span class='c-money'>$4</span> if <span class='c-attention'>poker hand</span><br>is a <span class='c-attention'>High Card</span>,<br>poker hand changes<br>at end of round</div>"
+  },
+  {
+    "name": "To the Moon",
+    "image": "To the Moon.webp",
+    "status": false,
+    "id": "j_to_the_moon",
+    "description": "<div class='joker-description'>Earn an extra <span class='c-money'>$1</span> of<br><span class='c-attention'>interest</span> for every <span class='c-money'>$5</span> you<br>have at end of round</div>"
+  },
+  {
+    "name": "Trading Card",
+    "image": "Trading Card.webp",
+    "status": false,
+    "id": "j_trading",
+    "description": "<div class='joker-description'>If <span class='c-attention'>first discard</span> of round<br>has only <span class='c-attention'>1</span> card, destroy<br>it and earn <span class='c-money'>$3</span></div>"
+  },
+  {
+    "name": "Triboulet",
+    "image": "Triboulet.webp",
+    "status": false,
+    "id": "j_triboulet",
+    "description": "<div class='joker-description'>Played <span class='c-attention'>Kings</span> and<br><span class='c-attention'>Queens</span> each give<br><span class='x-mult c-red c-white'> X2 </span> Mult when scored</div>"
+  },
+  {
+    "name": "Troubadour",
+    "image": "Troubadour.webp",
+    "status": false,
+    "id": "j_troubadour",
+    "description": "<div class='joker-description'><span class='c-attention'>+2</span> hand size,<br><span class='c-blue'>-1</span> hand each round</div>"
+  },
+  {
+    "name": "Turtle Bean",
+    "image": "Turtle Bean.webp",
+    "status": false,
+    "id": "j_turtle_bean",
+    "description": "<div class='joker-description'><span class='c-attention'>+5</span> hand size,<br>reduces by<br><span class='c-red'>1</span> every round</div>"
+  },
+  {
+    "name": "Vagabond",
+    "image": "Vagabond.webp",
+    "status": false,
+    "id": "j_vagabond",
+    "description": "<div class='joker-description'>Create a <span class='c-purple'>Tarot</span> card<br>if hand is played<br>with <span class='c-money'>$4</span> or less</div>"
+  },
+  {
+    "name": "Vampire",
+    "image": "Vampire.webp",
+    "status": false,
+    "id": "j_vampire",
+    "description": "<div class='joker-description'>This Joker gains <span class='x-mult c-red c-white'> X0.1 </span> Mult<br>per scoring <span class='c-attention'>Enhanced card</span> played,<br>removes card <span class='c-attention'>Enhancement</span><br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Walkie Talkie",
+    "image": "Walkie Talkie.webp",
+    "status": false,
+    "id": "j_walkie_talkie",
+    "description": "<div class='joker-description'>Each played <span class='c-attention'>10</span> or <span class='c-attention'>4</span><br>gives <span class='c-chips'>+10</span> Chips and<br><span class='c-mult'>+4</span> Mult when scored</div>"
+  },
+  {
+    "name": "Wee Joker",
+    "image": "Wee Joker.webp",
+    "status": false,
+    "id": "j_wee",
+    "description": "<div class='joker-description'>This Joker gains<br><span class='c-chips'>+8</span> Chips when each<br>played <span class='c-attention'>2</span> is scored<br><span class='c-inactive'>(Currently </span><span class='c-chips'>+0</span><span class='c-inactive'> Chips)</span></div>"
+  },
+  {
+    "name": "Wily Joker",
+    "image": "Wily Joker.webp",
+    "status": false,
+    "id": "j_wily",
+    "description": "<div class='joker-description'><span class='c-chips'>+100</span> Chips if played<br>hand contains<br>a <span class='c-attention'>Three of a Kind</span></div>"
+  },
+  {
+    "name": "Wrathful Joker",
+    "image": "Wrathful Joker.webp",
+    "status": false,
+    "id": "j_wrathful_joker",
+    "description": "<div class='joker-description'>Played cards with<br><span class='c-spades'>Spades</span> suit give<br><span class='c-mult'>+3</span> Mult when scored</div>"
+  },
+  {
+    "name": "Yorick",
+    "image": "Yorick.webp",
+    "status": false,
+    "id": "j_yorick",
+    "description": "<div class='joker-description'>This Joker gains<br><span class='x-mult c-red c-white'> X1 </span> Mult every <span class='c-attention'>23<span class='c-inactive'> [23]</span></span><br>cards discarded<br><span class='c-inactive'>(Currently <span class='x-mult c-red c-white'> X1 </span></span><span class='c-inactive'> Mult)</span></div>"
+  },
+  {
+    "name": "Zany Joker",
+    "image": "Zany Joker.webp",
+    "status": false,
+    "id": "j_zany",
+    "description": "<div class='joker-description'><span class='c-red'>+12</span> Mult if played<br>hand contains<br>a <span class='c-attention'>Three of a Kind</span></div>"
+  }
 ]

--- a/static/jokers.json
+++ b/static/jokers.json
@@ -4,1049 +4,1199 @@
         "image": "8 Ball.webp",
         "status": false,
         "id": "j_8_ball",
-        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 4</span> chance for each<br>played <span class=\"c-attention\">8</span> to create a<br><span class=\"c-tarot\">Tarot</span> card when scored<br><span class=\"c-inactive\">(Must have room)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 4</span> chance for each<br>played <span class=\"c-attention\">8</span> to create a<br><span class=\"c-tarot\">Tarot</span> card when scored<br><span class=\"c-inactive\">(Must have room)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Abstract Joker",
         "image": "Abstract Joker.webp",
         "status": false,
         "id": "j_abstract",
-        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+3</span> Mult for<br>each <span class=\"c-attention\">Joker</span> card<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+3</span> Mult for<br>each <span class=\"c-attention\">Joker</span> card<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Acrobat",
         "image": "Acrobat.webp",
         "status": false,
         "id": "j_acrobat",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult on <span class=\"c-attention\">final</span><br><span class=\"c-attention\">hand</span> of round</div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult on <span class=\"c-attention\">final</span><br><span class=\"c-attention\">hand</span> of round</div>",
+        "rarity": 2
     },
     {
         "name": "Ancient Joker",
         "image": "Ancient Joker.webp",
         "status": false,
         "id": "j_ancient",
-        "description": "<div class=\"joker-description\">Each played card with<br><span class=\"variable\">Hearts</span> suit gives<br><span class=\"x-mult c-red c-white\"> X1.5 </span> Mult when scored,<br><span class=\"size-0-8\">suit changes at end of round</span></div>"
+        "description": "<div class=\"joker-description\">Each played card with<br><span class=\"variable\">Hearts</span> suit gives<br><span class=\"x-mult c-red c-white\"> X1.5 </span> Mult when scored,<br><span class=\"size-0-8\">suit changes at end of round</span></div>",
+        "rarity": 3
     },
     {
         "name": "Arrowhead",
         "image": "Arrowhead.webp",
         "status": false,
         "id": "j_arrowhead",
-        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-spades\">Spade</span> suit give<br><span class=\"c-chips\">+50</span> Chips when scored</div>"
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-spades\">Spade</span> suit give<br><span class=\"c-chips\">+50</span> Chips when scored</div>",
+        "rarity": 2
     },
     {
         "name": "Astronomer",
         "image": "Astronomer.webp",
         "status": false,
         "id": "j_astronomer",
-        "description": "<div class=\"joker-description\">All <span class=\"c-planet\">Planet</span> cards and<br><span class=\"c-planet\">Celestial Packs</span> in<br>the shop are <span class=\"c-attention\">free</span></div>"
+        "description": "<div class=\"joker-description\">All <span class=\"c-planet\">Planet</span> cards and<br><span class=\"c-planet\">Celestial Packs</span> in<br>the shop are <span class=\"c-attention\">free</span></div>",
+        "rarity": 2
     },
     {
         "name": "Banner",
         "image": "Banner.webp",
         "status": false,
         "id": "j_banner",
-        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+30</span> Chips for<br>each remaining<br><span class=\"c-attention\">discard</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+30</span> Chips for<br>each remaining<br><span class=\"c-attention\">discard</span></div>",
+        "rarity": 1
     },
     {
         "name": "Baron",
         "image": "Baron.webp",
         "status": false,
         "id": "j_baron",
-        "description": "<div class=\"joker-description\">Each <span class=\"c-attention\">King</span><br>held in hand<br>gives <span class=\"x-mult c-red c-white\"> X1.5 </span> Mult</div>"
+        "description": "<div class=\"joker-description\">Each <span class=\"c-attention\">King</span><br>held in hand<br>gives <span class=\"x-mult c-red c-white\"> X1.5 </span> Mult</div>",
+        "rarity": 3
     },
     {
         "name": "Baseball Card",
         "image": "Baseball Card.webp",
         "status": false,
         "id": "j_baseball",
-        "description": "<div class=\"joker-description\"><span class=\"c-green\">Uncommon</span> Jokers<br>each give <span class=\"x-mult c-red c-white\"> X1.5 </span> Mult</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-green\">Uncommon</span> Jokers<br>each give <span class=\"x-mult c-red c-white\"> X1.5 </span> Mult</div>",
+        "rarity": 3
     },
     {
         "name": "Blackboard",
         "image": "Blackboard.webp",
         "status": false,
         "id": "j_blackboard",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if all<br>cards held in hand<br>are <span class=\"c-spades\">Spades</span> or <span class=\"c-clubs\">Clubs</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if all<br>cards held in hand<br>are <span class=\"c-spades\">Spades</span> or <span class=\"c-clubs\">Clubs</span></div>",
+        "rarity": 2
     },
     {
         "name": "Bloodstone",
         "image": "Bloodstone.webp",
         "status": false,
         "id": "j_bloodstone",
-        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 2</span> chance for<br>played cards with<br><span class=\"c-hearts\">Heart</span> suit to give<br><span class=\"x-mult c-red c-white\"> X1.5 </span> Mult when scored</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 2</span> chance for<br>played cards with<br><span class=\"c-hearts\">Heart</span> suit to give<br><span class=\"x-mult c-red c-white\"> X1.5 </span> Mult when scored</div>",
+        "rarity": 2
     },
     {
         "name": "Blue Joker",
         "image": "Blue Joker.webp",
         "status": false,
         "id": "j_blue_joker",
-        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+2</span> Chips for each<br>remaining card in <span class=\"c-attention\">deck</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+52</span><span class=\"c-inactive\"> Chips)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+2</span> Chips for each<br>remaining card in <span class=\"c-attention\">deck</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+52</span><span class=\"c-inactive\"> Chips)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Blueprint",
         "image": "Blueprint.webp",
         "status": false,
         "id": "j_blueprint",
-        "description": "<div class=\"joker-description\">Copies ability of<br><span class=\"c-attention\">Joker</span> to the right</div>"
+        "description": "<div class=\"joker-description\">Copies ability of<br><span class=\"c-attention\">Joker</span> to the right</div>",
+        "rarity": 3
     },
     {
         "name": "Bootstraps",
         "image": "Bootstraps.webp",
         "status": false,
         "id": "j_bootstraps",
-        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+2</span> Mult for every<br><span class=\"c-money\">$5</span> you have<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+2</span> Mult for every<br><span class=\"c-money\">$5</span> you have<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Brainstorm",
         "image": "Brainstorm.webp",
         "status": false,
         "id": "j_brainstorm",
-        "description": "<div class=\"joker-description\">Copies the ability<br>of leftmost <span class=\"c-attention\">Joker</span></div>"
+        "description": "<div class=\"joker-description\">Copies the ability<br>of leftmost <span class=\"c-attention\">Joker</span></div>",
+        "rarity": 3
     },
     {
         "name": "Bull",
         "image": "Bull.webp",
         "status": false,
         "id": "j_bull",
-        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+2</span> Chips for<br>each <span class=\"c-money\">$1</span> you have<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+2</span> Chips for<br>each <span class=\"c-money\">$1</span> you have<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Burglar",
         "image": "Burglar.webp",
         "status": false,
         "id": "j_burglar",
-        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Blind</span> is selected,<br>gain <span class=\"c-blue\">+3</span> Hands and<br><span class=\"c-attention\">lose all discards</span></div>"
+        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Blind</span> is selected,<br>gain <span class=\"c-blue\">+3</span> Hands and<br><span class=\"c-attention\">lose all discards</span></div>",
+        "rarity": 2
     },
     {
         "name": "Burnt Joker",
         "image": "Burnt Joker.webp",
         "status": false,
         "id": "j_burnt",
-        "description": "<div class=\"joker-description\">Upgrade the level of<br>the first <span class=\"c-attention\">discarded</span><br>poker hand each round</div>"
+        "description": "<div class=\"joker-description\">Upgrade the level of<br>the first <span class=\"c-attention\">discarded</span><br>poker hand each round</div>",
+        "rarity": 3
     },
     {
         "name": "Business Card",
         "image": "Business Card.webp",
         "status": false,
         "id": "j_business",
-        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">face</span> cards have<br>a <span class=\"c-green\">1 in 2</span> chance to<br>give <span class=\"c-money\">$2</span> when scored</div>"
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">face</span> cards have<br>a <span class=\"c-green\">1 in 2</span> chance to<br>give <span class=\"c-money\">$2</span> when scored</div>",
+        "rarity": 1
     },
     {
         "name": "Campfire",
         "image": "Campfire.webp",
         "status": false,
         "id": "j_campfire",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\">X0.25</span> Mult<br>for each card <span class=\"c-attention\">sold</span>, resets<br>when <span class=\"c-attention\">Boss Blind</span> is defeated<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\">X0.25</span> Mult<br>for each card <span class=\"c-attention\">sold</span>, resets<br>when <span class=\"c-attention\">Boss Blind</span> is defeated<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 3
     },
     {
         "name": "Canio",
         "image": "Canio.webp",
         "status": false,
         "id": "j_caino",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X1 </span> Mult<br>when a <span class=\"c-attention\">face</span> card<br>is destroyed<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X1 </span> Mult<br>when a <span class=\"c-attention\">face</span> card<br>is destroyed<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 4
     },
     {
         "name": "Card Sharp",
         "image": "Card Sharp.webp",
         "status": false,
         "id": "j_card_sharp",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3.0 </span> Mult if played<br><span class=\"c-attention\">poker hand</span> has already<br>been played this round</div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3.0 </span> Mult if played<br><span class=\"c-attention\">poker hand</span> has already<br>been played this round</div>",
+        "rarity": 2
     },
     {
         "name": "Cartomancer",
         "image": "Cartomancer.webp",
         "status": false,
         "id": "j_cartomancer",
-        "description": "<div class=\"joker-description\">Create a <span class=\"c-tarot\">Tarot</span> card<br>when <span class=\"c-attention\">Blind</span> is selected<br><span class=\"c-inactive\">(Must have room)</span></div>"
+        "description": "<div class=\"joker-description\">Create a <span class=\"c-tarot\">Tarot</span> card<br>when <span class=\"c-attention\">Blind</span> is selected<br><span class=\"c-inactive\">(Must have room)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Castle",
         "image": "Castle.webp",
         "status": false,
         "id": "j_castle",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-chips\">+3</span> Chips<br>per discarded <span class=\"variable\">Hearts</span> card,<br>suit changes every round<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-chips\">+3</span> Chips<br>per discarded <span class=\"variable\">Hearts</span> card,<br>suit changes every round<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Cavendish",
         "image": "Cavendish.webp",
         "status": false,
         "id": "j_cavendish",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3.0 </span> Mult<br><span class=\"c-green\">1 in 1000</span> chance this<br>card is destroyed<br>at end of round</div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3.0 </span> Mult<br><span class=\"c-green\">1 in 1000</span> chance this<br>card is destroyed<br>at end of round</div>",
+        "rarity": 1
     },
     {
         "name": "Ceremonial Dagger",
         "image": "Ceremonial Dagger.webp",
         "status": false,
         "id": "j_ceremonial",
-        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Blind</span> is selected,<br>destroy Joker to the right<br>and permanently add <span class=\"c-attention\">double</span><br>its sell value to this <span class=\"c-red\">Mult</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Blind</span> is selected,<br>destroy Joker to the right<br>and permanently add <span class=\"c-attention\">double</span><br>its sell value to this <span class=\"c-red\">Mult</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Certificate",
         "image": "Certificate.webp",
         "status": false,
         "id": "j_certificate",
-        "description": "<div class=\"joker-description\">When round begins,<br>add a random <span class=\"c-attention\">playing</span><br><span class=\"c-attention\">card</span> with a random<br><span class=\"c-attention\">seal</span> to your hand</div>"
+        "description": "<div class=\"joker-description\">When round begins,<br>add a random <span class=\"c-attention\">playing</span><br><span class=\"c-attention\">card</span> with a random<br><span class=\"c-attention\">seal</span> to your hand</div>",
+        "rarity": 2
     },
     {
         "name": "Chaos the Clown",
         "image": "Chaos the Clown.webp",
         "status": false,
         "id": "j_chaos",
-        "description": "<div class=\"joker-description\"><span class=\"c-attention\">1</span> free <span class=\"c-green\">Reroll</span><br>per shop</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-attention\">1</span> free <span class=\"c-green\">Reroll</span><br>per shop</div>",
+        "rarity": 1
     },
     {
         "name": "Chicot",
         "image": "Chicot.webp",
         "status": false,
         "id": "j_chicot",
-        "description": "<div class=\"joker-description\">Disables effect of<br>every <span class=\"c-attention\">Boss Blind</span></div>"
+        "description": "<div class=\"joker-description\">Disables effect of<br>every <span class=\"c-attention\">Boss Blind</span></div>",
+        "rarity": 4
     },
     {
         "name": "Clever Joker",
         "image": "Clever Joker.webp",
         "status": false,
         "id": "j_clever",
-        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+80</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Two Pair</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+80</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Two Pair</span></div>",
+        "rarity": 1
     },
     {
         "name": "Cloud 9",
         "image": "Cloud 9.webp",
         "status": false,
         "id": "j_cloud_9",
-        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$1</span> for each<br><span class=\"c-attention\">9</span> in your <span class=\"c-attention\">full deck</span><br>at end of round<br><span class=\"c-inactive\">(Currently <span class=\"c-money\">$4</span></span><span class=\"c-inactive\">)</span></div>"
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$1</span> for each<br><span class=\"c-attention\">9</span> in your <span class=\"c-attention\">full deck</span><br>at end of round<br><span class=\"c-inactive\">(Currently <span class=\"c-money\">$4</span></span><span class=\"c-inactive\">)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Constellation",
         "image": "Constellation.webp",
         "status": false,
         "id": "j_constellation",
-        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"x-mult c-red c-white\"> X0.1 </span> Mult every time<br>a <span class=\"c-planet\">Planet</span> card is used<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"x-mult c-red c-white\"> X0.1 </span> Mult every time<br>a <span class=\"c-planet\">Planet</span> card is used<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Crafty Joker",
         "image": "Crafty Joker.webp",
         "status": false,
         "id": "j_crafty",
-        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+80</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Flush</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+80</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Flush</span></div>",
+        "rarity": 1
     },
     {
         "name": "Crazy Joker",
         "image": "Crazy Joker.webp",
         "status": false,
         "id": "j_crazy",
-        "description": "<div class=\"joker-description\"><span class=\"c-red\">+12</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Straight</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+12</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Straight</span></div>",
+        "rarity": 1
     },
     {
         "name": "Credit Card",
         "image": "Credit Card.webp",
         "status": false,
         "id": "j_credit_card",
-        "description": "<div class=\"joker-description\">Go up to<br><span class=\"c-red\">-$20</span> in debt</div>"
+        "description": "<div class=\"joker-description\">Go up to<br><span class=\"c-red\">-$20</span> in debt</div>",
+        "rarity": 1
     },
     {
         "name": "Delayed Gratification",
         "image": "Delayed Gratification.webp",
         "status": false,
         "id": "j_delayed_grat",
-        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$2</span> per <span class=\"c-attention\">discard</span> if<br>no discards are used<br>by end of the round</div>"
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$2</span> per <span class=\"c-attention\">discard</span> if<br>no discards are used<br>by end of the round</div>",
+        "rarity": 1
     },
     {
         "name": "Devious Joker",
         "image": "Devious Joker.webp",
         "status": false,
         "id": "j_devious",
-        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+100</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Straight</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+100</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Straight</span></div>",
+        "rarity": 1
     },
     {
         "name": "Diet Cola",
         "image": "Diet Cola.webp",
         "status": false,
         "id": "j_diet_cola",
-        "description": "<div class=\"joker-description\">Sell this card to<br>create a free<br><span class=\"c-attention\">Double Tag</span></div>"
+        "description": "<div class=\"joker-description\">Sell this card to<br>create a free<br><span class=\"c-attention\">Double Tag</span></div>",
+        "rarity": 2
     },
     {
         "name": "DNA",
         "image": "DNA.webp",
         "status": false,
         "id": "j_dna",
-        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">first hand</span> of round<br>has only <span class=\"c-attention\">1</span> card, add a<br>permanent copy to deck<br>and draw it to <span class=\"c-attention\">hand</span></div>"
+        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">first hand</span> of round<br>has only <span class=\"c-attention\">1</span> card, add a<br>permanent copy to deck<br>and draw it to <span class=\"c-attention\">hand</span></div>",
+        "rarity": 3
     },
     {
         "name": "Driver's License",
         "image": "Driver's License.webp",
         "status": false,
         "id": "j_drivers_license",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X#1# </span> Mult if you have<br>at least <span class=\"c-attention\">16</span> Enhanced<br>cards in your full deck<br><span class=\"c-inactive\">(Currently </span><span class=\"c-attention\">#2#</span><span class=\"c-inactive\">)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if you have<br>at least <span class=\"c-attention\">16</span> Enhanced<br>cards in your full deck<br><span class=\"c-inactive\">(Currently </span><span class=\"c-attention\">0</span><span class=\"c-inactive\">)</span></div>",
+        "rarity": 3
     },
     {
         "name": "Droll Joker",
         "image": "Droll Joker.webp",
         "status": false,
         "id": "j_droll",
-        "description": "<div class=\"joker-description\"><span class=\"c-red\">+10</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Flush</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+10</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Flush</span></div>",
+        "rarity": 1
     },
     {
         "name": "Drunkard",
         "image": "Drunkard.webp",
         "status": false,
         "id": "j_drunkard",
-        "description": "<div class=\"joker-description\"><span class=\"c-red\">+1</span> discard<br>each round</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+1</span> discard<br>each round</div>",
+        "rarity": 1
     },
     {
         "name": "Dusk",
         "image": "Dusk.webp",
         "status": false,
         "id": "j_dusk",
-        "description": "<div class=\"joker-description\">Retrigger all played<br>cards in <span class=\"c-attention\">final</span><br><span class=\"c-attention\">hand</span> of round</div>"
+        "description": "<div class=\"joker-description\">Retrigger all played<br>cards in <span class=\"c-attention\">final</span><br><span class=\"c-attention\">hand</span> of round</div>",
+        "rarity": 2
     },
     {
         "name": "Egg",
         "image": "Egg.webp",
         "status": false,
         "id": "j_egg",
-        "description": "<div class=\"joker-description\">Gains <span class=\"c-money\">$3</span> of<br><span class=\"c-attention\">sell value</span> at<br>end of round</div>"
+        "description": "<div class=\"joker-description\">Gains <span class=\"c-money\">$3</span> of<br><span class=\"c-attention\">sell value</span> at<br>end of round</div>",
+        "rarity": 1
     },
     {
         "name": "Erosion",
         "image": "Erosion.webp",
         "status": false,
         "id": "j_erosion",
-        "description": "<div class=\"joker-description\"><span class=\"c-red\">+4</span> Mult for each<br>card below <span class=\"c-attention\">52</span><br>in your full deck<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+4</span> Mult for each<br>card below <span class=\"c-attention\">52</span><br>in your full deck<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Even Steven",
         "image": "Even Steven.webp",
         "status": false,
         "id": "j_even_steven",
-        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-attention\">even</span> rank give<br><span class=\"c-mult\">+4</span> Mult when scored<br><span class=\"c-inactive\">(10, 8, 6, 4, 2)</span></div>"
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-attention\">even</span> rank give<br><span class=\"c-mult\">+4</span> Mult when scored<br><span class=\"c-inactive\">(10, 8, 6, 4, 2)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Faceless Joker",
         "image": "Faceless Joker.webp",
         "status": false,
         "id": "j_faceless",
-        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$5</span> if <span class=\"c-attention\">3</span> or<br>more <span class=\"c-attention\">face cards</span><br>are discarded<br>at the same time</div>"
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$5</span> if <span class=\"c-attention\">3</span> or<br>more <span class=\"c-attention\">face cards</span><br>are discarded<br>at the same time</div>",
+        "rarity": 1
     },
     {
         "name": "Fibonacci",
         "image": "Fibonacci.webp",
         "status": false,
         "id": "j_fibonacci",
-        "description": "<div class=\"joker-description\">Each played <span class=\"c-attention\">Ace</span>,<br><span class=\"c-attention\">2</span>, <span class=\"c-attention\">3</span>, <span class=\"c-attention\">5</span>, or <span class=\"c-attention\">8</span> gives<br><span class=\"c-mult\">+8</span> Mult when scored</div>"
+        "description": "<div class=\"joker-description\">Each played <span class=\"c-attention\">Ace</span>,<br><span class=\"c-attention\">2</span>, <span class=\"c-attention\">3</span>, <span class=\"c-attention\">5</span>, or <span class=\"c-attention\">8</span> gives<br><span class=\"c-mult\">+8</span> Mult when scored</div>",
+        "rarity": 2
     },
     {
         "name": "Flash Card",
         "image": "Flash Card.webp",
         "status": false,
         "id": "j_flash",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-mult\">+2</span> Mult<br>per <span class=\"c-attention\">reroll</span> in the shop<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-mult\">+2</span> Mult<br>per <span class=\"c-attention\">reroll</span> in the shop<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Flower Pot",
         "image": "Flower Pot.webp",
         "status": false,
         "id": "j_flower_pot",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if poker<br>hand contains a<br><span class=\"c-diamonds\">Diamond</span> card, <span class=\"c-clubs\">Club</span> card,<br><span class=\"c-hearts\">Heart</span> card, and <span class=\"c-spades\">Spade</span> card</div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if poker<br>hand contains a<br><span class=\"c-diamonds\">Diamond</span> card, <span class=\"c-clubs\">Club</span> card,<br><span class=\"c-hearts\">Heart</span> card, and <span class=\"c-spades\">Spade</span> card</div>",
+        "rarity": 2
     },
     {
         "name": "Fortune Teller",
         "image": "Fortune Teller.webp",
         "status": false,
         "id": "j_fortune_teller",
-        "description": "<div class=\"joker-description\"><span class=\"c-red\">+1</span> Mult per <span class=\"c-purple\">Tarot</span><br>card used this run<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\">)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+1</span> Mult per <span class=\"c-purple\">Tarot</span><br>card used this run<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\">)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Four Fingers",
         "image": "Four Fingers.webp",
         "status": false,
         "id": "j_four_fingers",
-        "description": "<div class=\"joker-description\">All <span class=\"c-attention\">Flushes</span> and<br><span class=\"c-attention\">Straights</span> can be<br>made with <span class=\"c-attention\">4</span> cards</div>"
+        "description": "<div class=\"joker-description\">All <span class=\"c-attention\">Flushes</span> and<br><span class=\"c-attention\">Straights</span> can be<br>made with <span class=\"c-attention\">4</span> cards</div>",
+        "rarity": 2
     },
     {
         "name": "Gift Card",
         "image": "Gift Card.webp",
         "status": false,
         "id": "j_gift",
-        "description": "<div class=\"joker-description\">Add <span class=\"c-money\">$1</span> of <span class=\"c-attention\">sell value</span><br>to every <span class=\"c-attention\">Joker</span> and<br><span class=\"c-attention\">Consumable</span> card at<br>end of round</div>"
+        "description": "<div class=\"joker-description\">Add <span class=\"c-money\">$1</span> of <span class=\"c-attention\">sell value</span><br>to every <span class=\"c-attention\">Joker</span> and<br><span class=\"c-attention\">Consumable</span> card at<br>end of round</div>",
+        "rarity": 2
     },
     {
         "name": "Glass Joker",
         "image": "Glass Joker.webp",
         "status": false,
         "id": "j_glass",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.75 </span> Mult<br>for every <span class=\"c-attention\">Glass Card</span><br>that is destroyed<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.75 </span> Mult<br>for every <span class=\"c-attention\">Glass Card</span><br>that is destroyed<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Gluttonous Joker",
         "image": "Gluttonous Joker.webp",
         "status": false,
         "id": "j_gluttenous_joker",
-        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-clubs\">Clubs</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>"
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-clubs\">Clubs</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>",
+        "rarity": 1
     },
     {
         "name": "Golden Joker",
         "image": "Golden Joker.webp",
         "status": false,
         "id": "j_golden",
-        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$4</span> at<br>end of round</div>"
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$4</span> at<br>end of round</div>",
+        "rarity": 1
     },
     {
         "name": "Golden Ticket",
         "image": "Golden Ticket.webp",
         "status": false,
         "id": "j_ticket",
-        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">Gold</span> cards<br>earn <span class=\"c-money\">$4</span> when scored</div>"
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">Gold</span> cards<br>earn <span class=\"c-money\">$4</span> when scored</div>",
+        "rarity": 1
     },
     {
         "name": "Greedy Joker",
         "image": "Greedy Joker.webp",
         "status": false,
         "id": "j_greedy_joker",
-        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-diamonds\">Diamonds</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>"
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-diamonds\">Diamonds</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>",
+        "rarity": 1
     },
     {
         "name": "Green Joker",
         "image": "Green Joker.webp",
         "status": false,
         "id": "j_green_joker",
-        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+1</span> Mult per hand played<br><span class=\"c-mult\">-1</span> Mult per discard<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+1</span> Mult per hand played<br><span class=\"c-mult\">-1</span> Mult per discard<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Gros Michel",
         "image": "Gros Michel.webp",
         "status": false,
         "id": "j_gros_michel",
-        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+15</span> Mult<br><span class=\"c-green\">1 in 6</span> chance this<br>card is destroyed<br>at end of round</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+15</span> Mult<br><span class=\"c-green\">1 in 6</span> chance this<br>card is destroyed<br>at end of round</div>",
+        "rarity": 1
     },
     {
         "name": "Hack",
         "image": "Hack.webp",
         "status": false,
         "id": "j_hack",
-        "description": "<div class=\"joker-description\">Retrigger<br>each played<br><span class=\"c-attention\">2</span>, <span class=\"c-attention\">3</span>, <span class=\"c-attention\">4</span>, or <span class=\"c-attention\">5</span></div>"
+        "description": "<div class=\"joker-description\">Retrigger<br>each played<br><span class=\"c-attention\">2</span>, <span class=\"c-attention\">3</span>, <span class=\"c-attention\">4</span>, or <span class=\"c-attention\">5</span></div>",
+        "rarity": 2
     },
     {
         "name": "Half Joker",
         "image": "Half Joker.webp",
         "status": false,
         "id": "j_half",
-        "description": "<div class=\"joker-description\"><span class=\"c-red\">+20</span> Mult if played<br>hand contains<br><span class=\"c-attention\">3</span> or fewer cards</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+20</span> Mult if played<br>hand contains<br><span class=\"c-attention\">3</span> or fewer cards</div>",
+        "rarity": 1
     },
     {
         "name": "Hallucination",
         "image": "Hallucination.webp",
         "status": false,
         "id": "j_hallucination",
-        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 2</span> chance to create<br>a <span class=\"c-tarot\">Tarot</span> card when any<br><span class=\"c-attention\">Booster Pack</span> is opened<br><span class=\"c-inactive\">(Must have room)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 2</span> chance to create<br>a <span class=\"c-tarot\">Tarot</span> card when any<br><span class=\"c-attention\">Booster Pack</span> is opened<br><span class=\"c-inactive\">(Must have room)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Hanging Chad",
         "image": "Hanging Chad.webp",
         "status": false,
         "id": "j_hanging_chad",
-        "description": "<div class=\"joker-description\">Retrigger <span class=\"c-attention\">first</span> played<br>card used in scoring<br><span class=\"c-attention\">2</span> additional times</div>"
+        "description": "<div class=\"joker-description\">Retrigger <span class=\"c-attention\">first</span> played<br>card used in scoring<br><span class=\"c-attention\">2</span> additional times</div>",
+        "rarity": 1
     },
     {
         "name": "Hiker",
         "image": "Hiker.webp",
         "status": false,
         "id": "j_hiker",
-        "description": "<div class=\"joker-description\">Every played <span class=\"c-attention\">card</span><br>permanently gains<br><span class=\"c-chips\">+5</span> Chips when scored</div>"
+        "description": "<div class=\"joker-description\">Every played <span class=\"c-attention\">card</span><br>permanently gains<br><span class=\"c-chips\">+5</span> Chips when scored</div>",
+        "rarity": 2
     },
     {
         "name": "Hit the Road",
         "image": "Hit the Road.webp",
         "status": false,
         "id": "j_hit_the_road",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.5 </span> Mult<br>for every <span class=\"c-attention\">Jack</span><br>discarded this round<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.5 </span> Mult<br>for every <span class=\"c-attention\">Jack</span><br>discarded this round<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 3
     },
     {
         "name": "Hologram",
         "image": "Hologram.webp",
         "status": false,
         "id": "j_hologram",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.25 </span> Mult<br>every time a <span class=\"c-attention\">playing card</span><br>is added to your deck<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.25 </span> Mult<br>every time a <span class=\"c-attention\">playing card</span><br>is added to your deck<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Ice Cream",
         "image": "Ice Cream.webp",
         "status": false,
         "id": "j_ice_cream",
-        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+100</span> Chips<br><span class=\"c-chips\">-5</span> Chips for<br>every hand played</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+100</span> Chips<br><span class=\"c-chips\">-5</span> Chips for<br>every hand played</div>",
+        "rarity": 1
     },
     {
         "name": "Invisible Joker",
         "image": "Invisible Joker.webp",
         "status": false,
         "id": "j_invisible",
-        "description": "<div class=\"joker-description\">After <span class=\"c-attention\">2</span> rounds,<br>sell this card to<br><span class=\"c-attention\">Duplicate</span> a random Joker<br><span class=\"c-inactive\">(Currently </span><span class=\"c-attention\">0</span><span class=\"c-inactive\">/2)</span></div>"
+        "description": "<div class=\"joker-description\">After <span class=\"c-attention\">2</span> rounds,<br>sell this card to<br><span class=\"c-attention\">Duplicate</span> a random Joker<br><span class=\"c-inactive\">(Currently </span><span class=\"c-attention\">0</span><span class=\"c-inactive\">/2)</span></div>",
+        "rarity": 3
     },
     {
         "name": "Joker",
         "image": "Joker.webp",
         "status": false,
         "id": "j_joker",
-        "description": "<div class=\"joker-description\"><span class=\"c-red\">+4</span> Mult</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+4</span> Mult</div>",
+        "rarity": 1
     },
     {
         "name": "Joker Stencil",
         "image": "Joker Stencil.webp",
         "status": false,
         "id": "j_stencil",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X1 </span> Mult for each<br>empty <span class=\"c-attention\">Joker</span> slot<br><span class=\"size-0-8\">Joker Stencil included</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\">)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X1 </span> Mult for each<br>empty <span class=\"c-attention\">Joker</span> slot<br><span class=\"size-0-8\">Joker Stencil included</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\">)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Jolly Joker",
         "image": "Jolly Joker.webp",
         "status": false,
         "id": "j_jolly",
-        "description": "<div class=\"joker-description\"><span class=\"c-red\">+8</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Pair</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+8</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Pair</span></div>",
+        "rarity": 1
     },
     {
         "name": "Juggler",
         "image": "Juggler.webp",
         "status": false,
         "id": "j_juggler",
-        "description": "<div class=\"joker-description\"><span class=\"c-attention\">+1</span> hand size</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-attention\">+1</span> hand size</div>",
+        "rarity": 1
     },
     {
         "name": "Loyalty Card",
         "image": "Loyalty Card.webp",
         "status": false,
         "id": "j_loyalty_card",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X4.0 </span> Mult every<br><span class=\"c-attention\">6</span> hands played<br><span class=\"c-inactive\"></span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X4.0 </span> Mult every<br><span class=\"c-attention\">6</span> hands played<br><span class=\"c-inactive\"></span></div>",
+        "rarity": 2
     },
     {
         "name": "Luchador",
         "image": "Luchador.webp",
         "status": false,
         "id": "j_luchador",
-        "description": "<div class=\"joker-description\">Sell this card to<br>disable the current<br><span class=\"c-attention\">Boss Blind</span></div>"
+        "description": "<div class=\"joker-description\">Sell this card to<br>disable the current<br><span class=\"c-attention\">Boss Blind</span></div>",
+        "rarity": 2
     },
     {
         "name": "Lucky Cat",
         "image": "Lucky Cat.webp",
         "status": false,
         "id": "j_lucky_cat",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.25 </span> Mult<br>every time a <span class=\"c-attention\">Lucky</span> card<br><span class=\"c-green\">successfully</span> triggers<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.25 </span> Mult<br>every time a <span class=\"c-attention\">Lucky</span> card<br><span class=\"c-green\">successfully</span> triggers<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Lusty Joker",
         "image": "Lusty Joker.webp",
         "status": false,
         "id": "j_lusty_joker",
-        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-hearts\">Hearts</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>"
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-hearts\">Hearts</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>",
+        "rarity": 1
     },
     {
         "name": "Mad Joker",
         "image": "Mad Joker.webp",
         "status": false,
         "id": "j_mad",
-        "description": "<div class=\"joker-description\"><span class=\"c-red\">+10</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Two Pair</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+10</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Two Pair</span></div>",
+        "rarity": 1
     },
     {
         "name": "Madness",
         "image": "Madness.webp",
         "status": false,
         "id": "j_madness",
-        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Small Blind</span> or <span class=\"c-attention\">Big Blind</span><br>is selected, gain <span class=\"x-mult c-red c-white\"> X0.5 </span> Mult<br>and <span class=\"c-attention\">destroy</span> a random Joker<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Small Blind</span> or <span class=\"c-attention\">Big Blind</span><br>is selected, gain <span class=\"x-mult c-red c-white\"> X0.5 </span> Mult<br>and <span class=\"c-attention\">destroy</span> a random Joker<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Mail-In Rebate",
         "image": "Mail-In Rebate.webp",
         "status": false,
         "id": "j_mail",
-        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$5</span> for each<br>discarded <span class=\"c-attention\">2</span>, rank<br>changes every round</div>"
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$5</span> for each<br>discarded <span class=\"c-attention\">2</span>, rank<br>changes every round</div>",
+        "rarity": 1
     },
     {
         "name": "Marble Joker",
         "image": "Marble Joker.webp",
         "status": false,
         "id": "j_marble",
-        "description": "<div class=\"joker-description\">Adds one <span class=\"c-attention\">Stone</span> card<br>to deck when<br><span class=\"c-attention\">Blind</span> is selected</div>"
+        "description": "<div class=\"joker-description\">Adds one <span class=\"c-attention\">Stone</span> card<br>to deck when<br><span class=\"c-attention\">Blind</span> is selected</div>",
+        "rarity": 2
     },
     {
         "name": "Matador",
         "image": "Matador.webp",
         "status": false,
         "id": "j_matador",
-        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$8</span> if played<br>hand triggers the<br><span class=\"c-attention\">Boss Blind</span> ability</div>"
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$8</span> if played<br>hand triggers the<br><span class=\"c-attention\">Boss Blind</span> ability</div>",
+        "rarity": 2
     },
     {
         "name": "Merry Andy",
         "image": "Merry Andy.webp",
         "status": false,
         "id": "j_merry_andy",
-        "description": "<div class=\"joker-description\"><span class=\"c-red\">+3</span> discards<br>each round,<br><span class=\"c-red\">-1</span> hand size</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+3</span> discards<br>each round,<br><span class=\"c-red\">-1</span> hand size</div>",
+        "rarity": 2
     },
     {
         "name": "Midas Mask",
         "image": "Midas Mask.webp",
         "status": false,
         "id": "j_midas_mask",
-        "description": "<div class=\"joker-description\">All played <span class=\"c-attention\">face</span> cards<br>become <span class=\"c-attention\">Gold</span> cards<br>when scored</div>"
+        "description": "<div class=\"joker-description\">All played <span class=\"c-attention\">face</span> cards<br>become <span class=\"c-attention\">Gold</span> cards<br>when scored</div>",
+        "rarity": 2
     },
     {
         "name": "Mime",
         "image": "Mime.webp",
         "status": false,
         "id": "j_mime",
-        "description": "<div class=\"joker-description\">Retrigger all<br>card <span class=\"c-attention\">held in</span><br><span class=\"c-attention\">hand</span> abilities</div>"
+        "description": "<div class=\"joker-description\">Retrigger all<br>card <span class=\"c-attention\">held in</span><br><span class=\"c-attention\">hand</span> abilities</div>",
+        "rarity": 2
     },
     {
         "name": "Misprint",
         "image": "Misprint.webp",
         "status": false,
         "id": "j_misprint",
-        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+[0 to 23]</span> Mult</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+[0 to 23]</span> Mult</div>",
+        "rarity": 1
     },
     {
         "name": "Mr. Bones",
         "image": "Mr. Bones.webp",
         "status": false,
         "id": "j_mr_bones",
-        "description": "<div class=\"joker-description\">Prevents Death<br>if chips scored<br>are at least <span class=\"c-attention\">25%</span><br>of required chips<br><span class=\"size-1-1 c-red enhanced-text\">self destructs</span></div>"
+        "description": "<div class=\"joker-description\">Prevents Death<br>if chips scored<br>are at least <span class=\"c-attention\">25%</span><br>of required chips<br><span class=\"size-1-1 c-red enhanced-text\">self destructs</span></div>",
+        "rarity": 2
     },
     {
         "name": "Mystic Summit",
         "image": "Mystic Summit.webp",
         "status": false,
         "id": "j_mystic_summit",
-        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+15</span> Mult when<br><span class=\"c-attention\">0</span> discards<br>remaining</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+15</span> Mult when<br><span class=\"c-attention\">0</span> discards<br>remaining</div>",
+        "rarity": 1
     },
     {
         "name": "Obelisk",
         "image": "Obelisk.webp",
         "status": false,
         "id": "j_obelisk",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.2 </span> Mult<br>per <span class=\"c-attention\">consecutive</span> hand played<br>without playing your<br>most played <span class=\"c-attention\">poker hand</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.2 </span> Mult<br>per <span class=\"c-attention\">consecutive</span> hand played<br>without playing your<br>most played <span class=\"c-attention\">poker hand</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 3
     },
     {
         "name": "Odd Todd",
         "image": "Odd Todd.webp",
         "status": false,
         "id": "j_odd_todd",
-        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-attention\">odd</span> rank give<br><span class=\"c-chips\">+31</span> Chips when scored<br><span class=\"c-inactive\">(A, 9, 7, 5, 3)</span></div>"
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-attention\">odd</span> rank give<br><span class=\"c-chips\">+31</span> Chips when scored<br><span class=\"c-inactive\">(A, 9, 7, 5, 3)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Onyx Agate",
         "image": "Onyx Agate.webp",
         "status": false,
         "id": "j_onyx_agate",
-        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-clubs\">Club</span> suit give<br><span class=\"c-mult\">+7</span> Mult when scored</div>"
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-clubs\">Club</span> suit give<br><span class=\"c-mult\">+7</span> Mult when scored</div>",
+        "rarity": 2
     },
     {
         "name": "Oops! All 6s",
         "image": "Oops! All 6s.webp",
         "status": false,
         "id": "j_oops",
-        "description": "<div class=\"joker-description\">Doubles all <span class=\"c-attention\">listed</span><br><span class=\"c-green c-e:1 c-s:1.1\">probabilities</span><br><span class=\"c-inactive\">(ex: </span><span class=\"c-green\">1 in 3</span><span class=\"c-inactive\"> -> </span><span class=\"c-green\">2 in 3</span><span class=\"c-inactive\">)</span></div>"
+        "description": "<div class=\"joker-description\">Doubles all <span class=\"c-attention\">listed</span><br><span class=\"c-green c-e:1 c-s:1.1\">probabilities</span><br><span class=\"c-inactive\">(ex: </span><span class=\"c-green\">1 in 3</span><span class=\"c-inactive\"> -> </span><span class=\"c-green\">2 in 3</span><span class=\"c-inactive\">)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Pareidolia",
         "image": "Pareidolia.webp",
         "status": false,
         "id": "j_pareidolia",
-        "description": "<div class=\"joker-description\">All cards are<br>considered<br><span class=\"c-attention\">face</span> cards</div>"
+        "description": "<div class=\"joker-description\">All cards are<br>considered<br><span class=\"c-attention\">face</span> cards</div>",
+        "rarity": 2
     },
     {
         "name": "Perkeo",
         "image": "Perkeo.webp",
         "status": false,
         "id": "j_perkeo",
-        "description": "<div class=\"joker-description\">Creates a <span class=\"c-dark-edition\">Negative</span> copy of<br><span class=\"c-attention\">1</span> random <span class=\"c-attention\">consumable</span><br>card in your possession<br>at the end of the <span class=\"c-attention\">shop</span></div>"
+        "description": "<div class=\"joker-description\">Creates a <span class=\"c-dark-edition\">Negative</span> copy of<br><span class=\"c-attention\">1</span> random <span class=\"c-attention\">consumable</span><br>card in your possession<br>at the end of the <span class=\"c-attention\">shop</span></div>",
+        "rarity": 4
     },
     {
         "name": "Photograph",
         "image": "Photograph.webp",
         "status": false,
         "id": "j_photograph",
-        "description": "<div class=\"joker-description\">First played <span class=\"c-attention\">face</span><br>card gives <span class=\"x-mult c-red c-white\"> X2 </span> Mult<br>when scored</div>"
+        "description": "<div class=\"joker-description\">First played <span class=\"c-attention\">face</span><br>card gives <span class=\"x-mult c-red c-white\"> X2 </span> Mult<br>when scored</div>",
+        "rarity": 1
     },
     {
         "name": "Popcorn",
         "image": "Popcorn.webp",
         "status": false,
         "id": "j_popcorn",
-        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+20</span> Mult<br><span class=\"c-mult\">-4</span> Mult per<br>round played</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-mult\">+20</span> Mult<br><span class=\"c-mult\">-4</span> Mult per<br>round played</div>",
+        "rarity": 1
     },
     {
         "name": "Raised Fist",
         "image": "Raised Fist.webp",
         "status": false,
         "id": "j_raised_fist",
-        "description": "<div class=\"joker-description\">Adds <span class=\"c-attention\">double</span> the rank<br>of <span class=\"c-attention\">lowest</span> ranked card<br>held in hand to Mult</div>"
+        "description": "<div class=\"joker-description\">Adds <span class=\"c-attention\">double</span> the rank<br>of <span class=\"c-attention\">lowest</span> ranked card<br>held in hand to Mult</div>",
+        "rarity": 1
     },
     {
         "name": "Ramen",
         "image": "Ramen.webp",
         "status": false,
         "id": "j_ramen",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult,<br>loses <span class=\"x-mult c-red c-white\"> X0.01 </span> Mult<br>per <span class=\"c-attention\">card</span> discarded</div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult,<br>loses <span class=\"x-mult c-red c-white\"> X0.01 </span> Mult<br>per <span class=\"c-attention\">card</span> discarded</div>",
+        "rarity": 2
     },
     {
         "name": "Red Card",
         "image": "Red Card.webp",
         "status": false,
         "id": "j_red_card",
-        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"c-red\">+3</span> Mult when any<br><span class=\"c-attention\">Booster Pack</span> is skipped<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"c-red\">+3</span> Mult when any<br><span class=\"c-attention\">Booster Pack</span> is skipped<br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Reserved Parking",
         "image": "Reserved Parking.webp",
         "status": false,
         "id": "j_reserved_parking",
-        "description": "<div class=\"joker-description\">Each <span class=\"c-attention\">face</span> card<br>held in hand has<br>a <span class=\"c-green\">1 in 2</span> chance<br>to give <span class=\"c-money\">$1</span></div>"
+        "description": "<div class=\"joker-description\">Each <span class=\"c-attention\">face</span> card<br>held in hand has<br>a <span class=\"c-green\">1 in 2</span> chance<br>to give <span class=\"c-money\">$1</span></div>",
+        "rarity": 1
     },
     {
         "name": "Ride the Bus",
         "image": "Ride the Bus.webp",
         "status": false,
         "id": "j_ride_the_bus",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-mult\">+1</span> Mult<br>per <span class=\"c-attention\">consecutive</span> hand<br>played without a<br>scoring <span class=\"c-attention\">face</span> card<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-mult\">+1</span> Mult<br>per <span class=\"c-attention\">consecutive</span> hand<br>played without a<br>scoring <span class=\"c-attention\">face</span> card<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+0</span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Riff-Raff",
         "image": "Riff-Raff.webp",
         "status": false,
         "id": "j_riff_raff",
-        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Blind</span> is selected,<br>create <span class=\"c-attention\">2 </span><span class=\"c-blue\">Common</span><span class=\"c-attention\"> Jokers</span><br><span class=\"c-inactive\">(Must have room)</span></div>"
+        "description": "<div class=\"joker-description\">When <span class=\"c-attention\">Blind</span> is selected,<br>create <span class=\"c-attention\">2 </span><span class=\"c-blue\">Common</span><span class=\"c-attention\"> Jokers</span><br><span class=\"c-inactive\">(Must have room)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Rocket",
         "image": "Rocket.webp",
         "status": false,
         "id": "j_rocket",
-        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$1</span> at end of round<br>Payout increases by <span class=\"c-money\">$2</span><br>when <span class=\"c-attention\">Boss Blind</span> is defeated</div>"
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$1</span> at end of round<br>Payout increases by <span class=\"c-money\">$2</span><br>when <span class=\"c-attention\">Boss Blind</span> is defeated</div>",
+        "rarity": 2
     },
     {
         "name": "Rough Gem",
         "image": "Rough Gem.webp",
         "status": false,
         "id": "j_rough_gem",
-        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-diamonds\">Diamond</span> suit earn<br><span class=\"c-money\">$1</span> when scored</div>"
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-diamonds\">Diamond</span> suit earn<br><span class=\"c-money\">$1</span> when scored</div>",
+        "rarity": 2
     },
     {
         "name": "Runner",
         "image": "Runner.webp",
         "status": false,
         "id": "j_runner",
-        "description": "<div class=\"joker-description\">Gains <span class=\"c-chips\">+15</span> Chips<br>if played hand<br>contains a <span class=\"c-attention\">Straight</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>"
+        "description": "<div class=\"joker-description\">Gains <span class=\"c-chips\">+15</span> Chips<br>if played hand<br>contains a <span class=\"c-attention\">Straight</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Satellite",
         "image": "Satellite.webp",
         "status": false,
         "id": "j_satellite",
-        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$1</span> at end of<br>round per unique <span class=\"c-planet\">Planet</span><br>card used this run<br><span class=\"c-inactive\">(Currently </span><span class=\"c-money\">$0</span><span class=\"c-inactive\">)</span></div>"
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$1</span> at end of<br>round per unique <span class=\"c-planet\">Planet</span><br>card used this run<br><span class=\"c-inactive\">(Currently </span><span class=\"c-money\">$0</span><span class=\"c-inactive\">)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Scary Face",
         "image": "Scary Face.webp",
         "status": false,
         "id": "j_scary_face",
-        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">face</span> cards<br>give <span class=\"c-chips\">+30</span> Chips<br>when scored</div>"
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">face</span> cards<br>give <span class=\"c-chips\">+30</span> Chips<br>when scored</div>",
+        "rarity": 1
     },
     {
         "name": "Scholar",
         "image": "Scholar.webp",
         "status": false,
         "id": "j_scholar",
-        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">Aces</span><br>give <span class=\"c-chips\">+20</span> Chips<br>and <span class=\"c-mult\">+4</span> Mult<br>when scored</div>"
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">Aces</span><br>give <span class=\"c-chips\">+20</span> Chips<br>and <span class=\"c-mult\">+4</span> Mult<br>when scored</div>",
+        "rarity": 1
     },
     {
         "name": "S\u00e9ance",
         "image": "S\u00e9ance.webp",
         "status": false,
         "id": "j_seance",
-        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">poker hand</span> is a<br><span class=\"c-attention\">Straight Flush</span>, create a<br>random <span class=\"c-spectral\">Spectral</span> card<br><span class=\"c-inactive\">(Must have room)</span></div>"
+        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">poker hand</span> is a<br><span class=\"c-attention\">Straight Flush</span>, create a<br>random <span class=\"c-spectral\">Spectral</span> card<br><span class=\"c-inactive\">(Must have room)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Seeing Double",
         "image": "Seeing Double.webp",
         "status": false,
         "id": "j_seeing_double",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult if played<br>hand has a scoring<br><span class=\"c-clubs\">Club</span> card and a scoring<br>card of any other <span class=\"c-attention\">suit</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult if played<br>hand has a scoring<br><span class=\"c-clubs\">Club</span> card and a scoring<br>card of any other <span class=\"c-attention\">suit</span></div>",
+        "rarity": 2
     },
     {
         "name": "Seltzer",
         "image": "Seltzer.webp",
         "status": false,
         "id": "j_selzer",
-        "description": "<div class=\"joker-description\">Retrigger all<br>cards played for<br>the next <span class=\"c-attention\">10</span> hands</div>"
+        "description": "<div class=\"joker-description\">Retrigger all<br>cards played for<br>the next <span class=\"c-attention\">10</span> hands</div>",
+        "rarity": 2
     },
     {
         "name": "Shoot the Moon",
         "image": "Shoot the Moon.webp",
         "status": false,
         "id": "j_shoot_the_moon",
-        "description": "<div class=\"joker-description\">Each <span class=\"c-attention\">Queen</span><br>held in hand<br>gives <span class=\"c-mult\">+13</span> Mult</div>"
+        "description": "<div class=\"joker-description\">Each <span class=\"c-attention\">Queen</span><br>held in hand<br>gives <span class=\"c-mult\">+13</span> Mult</div>",
+        "rarity": 1
     },
     {
         "name": "Shortcut",
         "image": "Shortcut.webp",
         "status": false,
         "id": "j_shortcut",
-        "description": "<div class=\"joker-description\">Allows <span class=\"c-attention\">Straights</span> to be<br>made with gaps of <span class=\"c-attention\">1 rank</span><br><span class=\"c-inactive\">(ex: </span><span class=\"c-attention\">10 8 6 5 3</span><span class=\"c-inactive\">)</span></div>"
+        "description": "<div class=\"joker-description\">Allows <span class=\"c-attention\">Straights</span> to be<br>made with gaps of <span class=\"c-attention\">1 rank</span><br><span class=\"c-inactive\">(ex: </span><span class=\"c-attention\">10 8 6 5 3</span><span class=\"c-inactive\">)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Showman",
         "image": "Showman.webp",
         "status": false,
         "id": "j_ring_master",
-        "description": "<div class=\"joker-description\"><span class=\"c-attention\">Joker</span>, <span class=\"c-tarot\">Tarot</span>, <span class=\"c-planet\">Planet</span>,<br>and <span class=\"c-spectral\">Spectral</span> cards may<br>appear multiple times</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-attention\">Joker</span>, <span class=\"c-tarot\">Tarot</span>, <span class=\"c-planet\">Planet</span>,<br>and <span class=\"c-spectral\">Spectral</span> cards may<br>appear multiple times</div>",
+        "rarity": 2
     },
     {
         "name": "Sixth Sense",
         "image": "Sixth Sense.webp",
         "status": false,
         "id": "j_sixth_sense",
-        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">first hand</span> of round is<br>a single <span class=\"c-attention\">6</span>, destroy it and<br>create a <span class=\"c-spectral\">Spectral</span> card<br><span class=\"c-inactive\">(Must have room)</span></div>"
+        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">first hand</span> of round is<br>a single <span class=\"c-attention\">6</span>, destroy it and<br>create a <span class=\"c-spectral\">Spectral</span> card<br><span class=\"c-inactive\">(Must have room)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Sly Joker",
         "image": "Sly Joker.webp",
         "status": false,
         "id": "j_sly",
-        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+50</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Pair</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+50</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Pair</span></div>",
+        "rarity": 1
     },
     {
         "name": "Smeared Joker",
         "image": "Smeared Joker.webp",
         "status": false,
         "id": "j_smeared",
-        "description": "<div class=\"joker-description\"><span class=\"c-hearts\">Hearts</span> and <span class=\"c-diamonds\">Diamonds</span><br>count as the same suit,<br><span class=\"c-spades\">Spades</span> and <span class=\"c-clubs\">Clubs</span><br>count as the same suit</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-hearts\">Hearts</span> and <span class=\"c-diamonds\">Diamonds</span><br>count as the same suit,<br><span class=\"c-spades\">Spades</span> and <span class=\"c-clubs\">Clubs</span><br>count as the same suit</div>",
+        "rarity": 2
     },
     {
         "name": "Smiley Face",
         "image": "Smiley Face.webp",
         "status": false,
         "id": "j_smiley",
-        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">face</span> cards<br>give <span class=\"c-mult\">+5</span> Mult<br>when scored</div>"
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">face</span> cards<br>give <span class=\"c-mult\">+5</span> Mult<br>when scored</div>",
+        "rarity": 1
     },
     {
         "name": "Sock and Buskin",
         "image": "Sock and Buskin.webp",
         "status": false,
         "id": "j_sock_and_buskin",
-        "description": "<div class=\"joker-description\">Retrigger all<br>played <span class=\"c-attention\">face</span> cards</div>"
+        "description": "<div class=\"joker-description\">Retrigger all<br>played <span class=\"c-attention\">face</span> cards</div>",
+        "rarity": 2
     },
     {
         "name": "Space Joker",
         "image": "Space Joker.webp",
         "status": false,
         "id": "j_space",
-        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 4</span> chance to<br>upgrade level of<br>played <span class=\"c-attention\">poker hand</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-green\">1 in 4</span> chance to<br>upgrade level of<br>played <span class=\"c-attention\">poker hand</span></div>",
+        "rarity": 2
     },
     {
         "name": "Spare Trousers",
         "image": "Spare Trousers.webp",
         "status": false,
         "id": "j_trousers",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-mult\">+2</span> Mult<br>if played hand contains<br>a <span class=\"c-attention\">Two Pair</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-mult\">+2</span> Mult<br>if played hand contains<br>a <span class=\"c-attention\">Two Pair</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-red\">+0</span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Splash",
         "image": "Splash.webp",
         "status": false,
         "id": "j_splash",
-        "description": "<div class=\"joker-description\">Every <span class=\"c-attention\">played card</span><br>counts in scoring</div>"
+        "description": "<div class=\"joker-description\">Every <span class=\"c-attention\">played card</span><br>counts in scoring</div>",
+        "rarity": 1
     },
     {
         "name": "Square Joker",
         "image": "Square Joker.webp",
         "status": false,
         "id": "j_square",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-chips\">+4</span> Chips<br>if played hand has<br>exactly <span class=\"c-attention\">4</span> cards<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">0</span><span class=\"c-inactive\"> Chips)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-chips\">+4</span> Chips<br>if played hand has<br>exactly <span class=\"c-attention\">4</span> cards<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">0</span><span class=\"c-inactive\"> Chips)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Steel Joker",
         "image": "Steel Joker.webp",
         "status": false,
         "id": "j_steel_joker",
-        "description": "<div class=\"joker-description\">Gives <span class=\"x-mult c-red c-white\"> X0.2 </span> Mult<br>for each <span class=\"c-attention\">Steel Card</span><br>in your <span class=\"c-attention\">full deck</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">Gives <span class=\"x-mult c-red c-white\"> X0.2 </span> Mult<br>for each <span class=\"c-attention\">Steel Card</span><br>in your <span class=\"c-attention\">full deck</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Stone Joker",
         "image": "Stone Joker.webp",
         "status": false,
         "id": "j_stone",
-        "description": "<div class=\"joker-description\">Gives <span class=\"c-chips\">+25</span> Chips for<br>each <span class=\"c-attention\">Stone Card</span><br>in your <span class=\"c-attention\">full deck</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>"
+        "description": "<div class=\"joker-description\">Gives <span class=\"c-chips\">+25</span> Chips for<br>each <span class=\"c-attention\">Stone Card</span><br>in your <span class=\"c-attention\">full deck</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Stuntman",
         "image": "Stuntman.webp",
         "status": false,
         "id": "j_stuntman",
-        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+250</span> Chips,<br><span class=\"c-attention\">-2</span> hand size</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+250</span> Chips,<br><span class=\"c-attention\">-2</span> hand size</div>",
+        "rarity": 3
     },
     {
         "name": "Supernova",
         "image": "Supernova.webp",
         "status": false,
         "id": "j_supernova",
-        "description": "<div class=\"joker-description\">Adds the number of times<br><span class=\"c-attention\">poker hand</span> has been<br>played this run to Mult</div>"
+        "description": "<div class=\"joker-description\">Adds the number of times<br><span class=\"c-attention\">poker hand</span> has been<br>played this run to Mult</div>",
+        "rarity": 1
     },
     {
         "name": "Superposition",
         "image": "Superposition.webp",
         "status": false,
         "id": "j_superposition",
-        "description": "<div class=\"joker-description\">Create a <span class=\"c-tarot\">Tarot</span> card if<br>poker hand contains an<br><span class=\"c-attention\">Ace</span> and a <span class=\"c-attention\">Straight</span><br><span class=\"c-inactive\">(Must have room)</span></div>"
+        "description": "<div class=\"joker-description\">Create a <span class=\"c-tarot\">Tarot</span> card if<br>poker hand contains an<br><span class=\"c-attention\">Ace</span> and a <span class=\"c-attention\">Straight</span><br><span class=\"c-inactive\">(Must have room)</span></div>",
+        "rarity": 1
     },
     {
         "name": "Swashbuckler",
         "image": "Swashbuckler.webp",
         "status": false,
         "id": "j_swashbuckler",
-        "description": "<div class=\"joker-description\">Adds the sell value<br>of all other owned<br><span class=\"c-attention\">Jokers</span> to Mult<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+1</span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">Adds the sell value<br>of all other owned<br><span class=\"c-attention\">Jokers</span> to Mult<br><span class=\"c-inactive\">(Currently </span><span class=\"c-mult\">+1</span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 1
     },
     {
         "name": "The Duo",
         "image": "The Duo.webp",
         "status": false,
         "id": "j_duo",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Pair</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Pair</span></div>",
+        "rarity": 3
     },
     {
         "name": "The Family",
         "image": "The Family.webp",
         "status": false,
         "id": "j_family",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X4 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Four of a Kind</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X4 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Four of a Kind</span></div>",
+        "rarity": 3
     },
     {
         "name": "The Idol",
         "image": "The Idol.webp",
         "status": false,
         "id": "j_idol",
-        "description": "<div class=\"joker-description\">Each played <span class=\"c-attention\">2</span><br>of <span class=\"variable\">Spades</span> gives<br><span class=\"x-mult c-red c-white\"> X2 </span> Mult when scored<br><span class=\"size-0-8\">Card changes every round</span></div>"
+        "description": "<div class=\"joker-description\">Each played <span class=\"c-attention\">2</span><br>of <span class=\"variable\">Spades</span> gives<br><span class=\"x-mult c-red c-white\"> X2 </span> Mult when scored<br><span class=\"size-0-8\">Card changes every round</span></div>",
+        "rarity": 2
     },
     {
         "name": "The Order",
         "image": "The Order.webp",
         "status": false,
         "id": "j_order",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Straight</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Straight</span></div>",
+        "rarity": 3
     },
     {
         "name": "The Tribe",
         "image": "The Tribe.webp",
         "status": false,
         "id": "j_tribe",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Flush</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X2 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Flush</span></div>",
+        "rarity": 3
     },
     {
         "name": "The Trio",
         "image": "The Trio.webp",
         "status": false,
         "id": "j_trio",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Three of a Kind</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X3 </span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Three of a Kind</span></div>",
+        "rarity": 3
     },
     {
         "name": "Throwback",
         "image": "Throwback.webp",
         "status": false,
         "id": "j_throwback",
-        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X0.25 </span> Mult for each<br><span class=\"c-attention\">Blind</span> skipped this run<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"x-mult c-red c-white\"> X0.25 </span> Mult for each<br><span class=\"c-attention\">Blind</span> skipped this run<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "To Do List",
         "image": "To Do List.webp",
         "status": false,
         "id": "j_todo_list",
-        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$4</span> if <span class=\"c-attention\">poker hand</span><br>is a <span class=\"c-attention\">High Card</span>,<br>poker hand changes<br>at end of round</div>"
+        "description": "<div class=\"joker-description\">Earn <span class=\"c-money\">$4</span> if <span class=\"c-attention\">poker hand</span><br>is a <span class=\"c-attention\">High Card</span>,<br>poker hand changes<br>at end of round</div>",
+        "rarity": 1
     },
     {
         "name": "To the Moon",
         "image": "To the Moon.webp",
         "status": false,
         "id": "j_to_the_moon",
-        "description": "<div class=\"joker-description\">Earn an extra <span class=\"c-money\">$1</span> of<br><span class=\"c-attention\">interest</span> for every <span class=\"c-money\">$5</span> you<br>have at end of round</div>"
+        "description": "<div class=\"joker-description\">Earn an extra <span class=\"c-money\">$1</span> of<br><span class=\"c-attention\">interest</span> for every <span class=\"c-money\">$5</span> you<br>have at end of round</div>",
+        "rarity": 2
     },
     {
         "name": "Trading Card",
         "image": "Trading Card.webp",
         "status": false,
         "id": "j_trading",
-        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">first discard</span> of round<br>has only <span class=\"c-attention\">1</span> card, destroy<br>it and earn <span class=\"c-money\">$3</span></div>"
+        "description": "<div class=\"joker-description\">If <span class=\"c-attention\">first discard</span> of round<br>has only <span class=\"c-attention\">1</span> card, destroy<br>it and earn <span class=\"c-money\">$3</span></div>",
+        "rarity": 2
     },
     {
         "name": "Triboulet",
         "image": "Triboulet.webp",
         "status": false,
         "id": "j_triboulet",
-        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">Kings</span> and<br><span class=\"c-attention\">Queens</span> each give<br><span class=\"x-mult c-red c-white\"> X2 </span> Mult when scored</div>"
+        "description": "<div class=\"joker-description\">Played <span class=\"c-attention\">Kings</span> and<br><span class=\"c-attention\">Queens</span> each give<br><span class=\"x-mult c-red c-white\"> X2 </span> Mult when scored</div>",
+        "rarity": 4
     },
     {
         "name": "Troubadour",
         "image": "Troubadour.webp",
         "status": false,
         "id": "j_troubadour",
-        "description": "<div class=\"joker-description\"><span class=\"c-attention\">+2</span> hand size,<br><span class=\"c-blue\">-1</span> hand each round</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-attention\">+2</span> hand size,<br><span class=\"c-blue\">-1</span> hand each round</div>",
+        "rarity": 2
     },
     {
         "name": "Turtle Bean",
         "image": "Turtle Bean.webp",
         "status": false,
         "id": "j_turtle_bean",
-        "description": "<div class=\"joker-description\"><span class=\"c-attention\">+5</span> hand size,<br>reduces by<br><span class=\"c-red\">1</span> every round</div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-attention\">+5</span> hand size,<br>reduces by<br><span class=\"c-red\">1</span> every round</div>",
+        "rarity": 2
     },
     {
         "name": "Vagabond",
         "image": "Vagabond.webp",
         "status": false,
         "id": "j_vagabond",
-        "description": "<div class=\"joker-description\">Create a <span class=\"c-purple\">Tarot</span> card<br>if hand is played<br>with <span class=\"c-money\">$4</span> or less</div>"
+        "description": "<div class=\"joker-description\">Create a <span class=\"c-purple\">Tarot</span> card<br>if hand is played<br>with <span class=\"c-money\">$4</span> or less</div>",
+        "rarity": 3
     },
     {
         "name": "Vampire",
         "image": "Vampire.webp",
         "status": false,
         "id": "j_vampire",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.1 </span> Mult<br>per scoring <span class=\"c-attention\">Enhanced card</span> played,<br>removes card <span class=\"c-attention\">Enhancement</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"x-mult c-red c-white\"> X0.1 </span> Mult<br>per scoring <span class=\"c-attention\">Enhanced card</span> played,<br>removes card <span class=\"c-attention\">Enhancement</span><br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 2
     },
     {
         "name": "Walkie Talkie",
         "image": "Walkie Talkie.webp",
         "status": false,
         "id": "j_walkie_talkie",
-        "description": "<div class=\"joker-description\">Each played <span class=\"c-attention\">10</span> or <span class=\"c-attention\">4</span><br>gives <span class=\"c-chips\">+10</span> Chips and<br><span class=\"c-mult\">+4</span> Mult when scored</div>"
+        "description": "<div class=\"joker-description\">Each played <span class=\"c-attention\">10</span> or <span class=\"c-attention\">4</span><br>gives <span class=\"c-chips\">+10</span> Chips and<br><span class=\"c-mult\">+4</span> Mult when scored</div>",
+        "rarity": 1
     },
     {
         "name": "Wee Joker",
         "image": "Wee Joker.webp",
         "status": false,
         "id": "j_wee",
-        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"c-chips\">+8</span> Chips when each<br>played <span class=\"c-attention\">2</span> is scored<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"c-chips\">+8</span> Chips when each<br>played <span class=\"c-attention\">2</span> is scored<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>",
+        "rarity": 3
     },
     {
         "name": "Wily Joker",
         "image": "Wily Joker.webp",
         "status": false,
         "id": "j_wily",
-        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+100</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Three of a Kind</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+100</span> Chips if played<br>hand contains<br>a <span class=\"c-attention\">Three of a Kind</span></div>",
+        "rarity": 1
     },
     {
         "name": "Wrathful Joker",
         "image": "Wrathful Joker.webp",
         "status": false,
         "id": "j_wrathful_joker",
-        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-spades\">Spades</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>"
+        "description": "<div class=\"joker-description\">Played cards with<br><span class=\"c-spades\">Spades</span> suit give<br><span class=\"c-mult\">+3</span> Mult when scored</div>",
+        "rarity": 1
     },
     {
         "name": "Yorick",
         "image": "Yorick.webp",
         "status": false,
         "id": "j_yorick",
-        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"x-mult c-red c-white\"> X1 </span> Mult every <span class=\"c-attention\">23<span class=\"c-inactive\"> [23]</span></span><br>cards discarded<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>"
+        "description": "<div class=\"joker-description\">This Joker gains<br><span class=\"x-mult c-red c-white\"> X1 </span> Mult every <span class=\"c-attention\">23<span class=\"c-inactive\"> [23]</span></span><br>cards discarded<br><span class=\"c-inactive\">(Currently <span class=\"x-mult c-red c-white\"> X1 </span></span><span class=\"c-inactive\"> Mult)</span></div>",
+        "rarity": 4
     },
     {
         "name": "Zany Joker",
         "image": "Zany Joker.webp",
         "status": false,
         "id": "j_zany",
-        "description": "<div class=\"joker-description\"><span class=\"c-red\">+12</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Three of a Kind</span></div>"
+        "description": "<div class=\"joker-description\"><span class=\"c-red\">+12</span> Mult if played<br>hand contains<br>a <span class=\"c-attention\">Three of a Kind</span></div>",
+        "rarity": 1
     }
 ]

--- a/static/jokers.json
+++ b/static/jokers.json
@@ -28,7 +28,7 @@
         "image": "Ancient Joker.webp",
         "status": false,
         "id": "j_ancient",
-        "description": "<div class=\"joker-description\">Each played card with<br><span class=\"variable\">Hearts</span> suit gives<br><span class=\"x-mult c-red c-white\"> X1.5 </span> Mult when scored,<br><span class=\"size-0-8\">suit changes at end of round</span></div>",
+        "description": "<div class=\"joker-description\">Each played card with<br><span class=\"variable\">[random suit]</span> suit gives<br><span class=\"x-mult c-red c-white\"> X1.5 </span> Mult when scored,<br><span class=\"size-0-8\">suit changes at end of round</span></div>",
         "rarity": 3
     },
     {
@@ -92,7 +92,7 @@
         "image": "Blue Joker.webp",
         "status": false,
         "id": "j_blue_joker",
-        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+2</span> Chips for each<br>remaining card in <span class=\"c-attention\">deck</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+52</span><span class=\"c-inactive\"> Chips)</span></div>",
+        "description": "<div class=\"joker-description\"><span class=\"c-chips\">+2</span> Chips for each<br>remaining card in <span class=\"c-attention\">deck</span><br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+104</span><span class=\"c-inactive\"> Chips)</span></div>",
         "rarity": 1
     },
     {
@@ -188,7 +188,7 @@
         "image": "Castle.webp",
         "status": false,
         "id": "j_castle",
-        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-chips\">+3</span> Chips<br>per discarded <span class=\"variable\">Hearts</span> card,<br>suit changes every round<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>",
+        "description": "<div class=\"joker-description\">This Joker gains <span class=\"c-chips\">+3</span> Chips<br>per discarded <span class=\"variable\">[random owned suit]</span> card,<br>suit changes every round<br><span class=\"c-inactive\">(Currently </span><span class=\"c-chips\">+0</span><span class=\"c-inactive\"> Chips)</span></div>",
         "rarity": 2
     },
     {

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -2,14 +2,16 @@ let currentView = 'all';
 let currentActiveButton = null;
 const staticDir = "./static/";
 let totalJokers = 0;
-let jokersData = {};
+const jokerTooltipData = {};
+let tooltipTimer = null;
+let currentHoveredCard = null;
+let currentMousePosition = { x: 0, y: 0 };
 
 document.addEventListener('DOMContentLoaded', () => {
     initPage()
         .then(() => {
             setDefaultView();
             updateStats();
-            initTooltips();
         });
 });
 
@@ -22,9 +24,6 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
         stickyHeader.classList.remove('sticky-active');
     }
-    
-    // Hide tooltip when scrolling
-    hideTooltip();
 });
 
 
@@ -48,6 +47,13 @@ function generateJokerGrid(jokers) {
             </div>
         `;
         container.innerHTML += jokerHtml;
+        
+        // add tooltip listeners
+        jokerTooltipData[joker.id] = {
+            name: joker.name,
+            description: joker.description,
+            rarity: joker.rarity
+        };
     });
 }
 
@@ -66,13 +72,6 @@ function initPage() {
     })
     .then(data => {
         totalJokers = data.length;
-        
-        // Store jokers data for tooltip lookup
-        jokersData = {};
-        data.forEach(joker => {
-            jokersData[joker.id] = joker;
-        });
-        
         // console.log('Success:', data);
         generateJokerGrid(data);
     })
@@ -80,95 +79,6 @@ function initPage() {
         console.error('Error:', error);
         alert('Error, check the console');
    });
-}
-
-function initTooltips() {
-    const tooltip = document.getElementById('joker-tooltip');
-    console.log('Initializing tooltips...');
-    
-    // Add hover listeners to all joker cards
-    document.addEventListener('mouseover', function(e) {
-        const card = e.target.closest('.card');
-        if (card && card.id) {
-            console.log('Hovering over card:', card.id);
-            showTooltip(card, e);
-        }
-    });
-    
-    document.addEventListener('mouseout', function(e) {
-        const card = e.target.closest('.card');
-        if (card && card.id) {
-            hideTooltip();
-        }
-    });
-    
-    document.addEventListener('mousemove', function(e) {
-        const card = e.target.closest('.card');
-        if (card && card.id && tooltip.classList.contains('show')) {
-            updateTooltipPosition(e);
-        }
-    });
-}
-
-function showTooltip(card, event) {
-    const tooltip = document.getElementById('joker-tooltip');
-    
-    // Get joker data directly using the card ID
-    const jokerData = jokersData[card.id];
-    
-    if (!jokerData) {
-        console.warn('No joker data found for:', card.id);
-        return;
-    }
-    
-    // Update tooltip content
-    tooltip.querySelector('.tooltip-title').textContent = jokerData.name;
-    tooltip.querySelector('.tooltip-description').innerHTML = jokerData.description;
-    
-    // Position and show tooltip
-    updateTooltipPosition(event);
-    tooltip.classList.add('show');
-}
-
-function hideTooltip() {
-    const tooltip = document.getElementById('joker-tooltip');
-    tooltip.classList.remove('show');
-}
-
-function updateTooltipPosition(event) {
-    const tooltip = document.getElementById('joker-tooltip');
-    const mouseX = event.clientX;
-    const mouseY = event.clientY;
-    const offset = 15;
-    
-    // Get tooltip dimensions
-    const tooltipRect = tooltip.getBoundingClientRect();
-    const windowWidth = window.innerWidth;
-    const windowHeight = window.innerHeight;
-    
-    // Center the tooltip horizontally under the cursor (accounting for scroll)
-    let left = mouseX - (tooltipRect.width / 2);
-    let top = mouseY + offset;
-    
-    // Adjust horizontal position if tooltip would go off screen
-    if (left < 5) {
-        left = 5;
-    } else if (left + tooltipRect.width > windowWidth - 5) {
-        left = windowWidth - tooltipRect.width - 5;
-    }
-    
-    // Adjust vertical position if tooltip would go off screen
-    if (top + tooltipRect.height > windowHeight - 5) {
-        top = mouseY - tooltipRect.height - offset;
-    }
-    
-    // Ensure tooltip doesn't go off the top edge
-    top = Math.max(5, top);
-    
-    // Apply positioning with scroll offset
-    tooltip.style.left = left + 'px';
-    tooltip.style.top = top + 'px';
-    tooltip.style.position = 'fixed'; // Use fixed positioning relative to viewport
 }
 
 function handleCardClick(card) {
@@ -380,4 +290,175 @@ function setStatsFromProfile(jokers){
         checkbox.dispatchEvent(event);
    });
     updateStats();
+}
+
+function setupTooltipEvents() {
+    const tooltip = document.getElementById('joker-tooltip');
+    // Add tooltip event listeners (only once, outside the loop)
+    document.addEventListener('mouseover', function(e) {
+        const card = e.target.closest('.card');
+        if (card && card.id) {
+            startTooltipTimer(card, e);
+        }
+    });
+
+    document.addEventListener('mouseout', function(e) {
+        const card = e.target.closest('.card');
+        if (card && card.id) {
+            clearTooltipTimer();
+            hideTooltip();
+        }
+    });
+
+    document.addEventListener('mousemove', function(e) {
+        const card = e.target.closest('.card');
+        if (card && card.id) {
+            // Update stored mouse position
+            currentMousePosition = { x: e.clientX, y: e.clientY };
+            
+            // If we're hovering over a different card, restart the timer
+            if (currentHoveredCard !== card.id) {
+                clearTooltipTimer();
+                startTooltipTimer(card, e);
+            }
+            // If tooltip is already showing, update its position
+            if (tooltip.classList.contains('show')) {
+                updateTooltipPosition(e);
+            }
+        } else {
+            clearTooltipTimer();
+            hideTooltip();
+        }
+    });
+
+    document.addEventListener('scroll', function(e) {
+        hideTooltip();
+    });
+}
+
+function startTooltipTimer(card, e) {
+    clearTooltipTimer();
+    currentHoveredCard = card.id;
+    currentMousePosition = { x: e.clientX, y: e.clientY };
+    
+    tooltipTimer = setTimeout(() => {
+        showTooltip(card);
+    }, 500);
+}
+
+function clearTooltipTimer() {
+    if (tooltipTimer) {
+        clearTimeout(tooltipTimer);
+        tooltipTimer = null;
+    }
+    currentHoveredCard = null;
+}
+
+function showTooltip(card) {
+    const tooltip = document.getElementById('joker-tooltip');
+    
+    // Get joker data directly using the card ID
+    const jokerData = jokerTooltipData[card.id];
+    
+    if (!jokerData) {
+        console.warn('No joker data found for:', card.id);
+        return;
+    }
+    
+    // Map rarity numbers to display names
+    const rarityNames = {
+        1: 'Common',
+        2: 'Uncommon', 
+        3: 'Rare',
+        4: 'Legendary'
+    };
+    
+    // Update tooltip content
+    tooltip.querySelector('.tooltip-title').textContent = jokerData.name;
+    
+    const rarityElement = tooltip.querySelector('.tooltip-rarity');
+    const rarity = jokerData.rarity;
+    rarityElement.textContent = rarityNames[rarity] || 'Unknown';
+    rarityElement.className = `tooltip-rarity rarity-${rarity}`;
+    
+    tooltip.querySelector('.tooltip-description').innerHTML = jokerData.description;
+    
+    // Position and show tooltip using stored mouse position
+    updateTooltipPositionFromCoords(currentMousePosition.x, currentMousePosition.y);
+    tooltip.classList.add('show');
+}
+
+function updateTooltipPositionFromCoords(mouseX, mouseY) {
+    const tooltip = document.getElementById('joker-tooltip');
+    const offset = 15;
+    
+    // Get tooltip dimensions
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const windowWidth = window.innerWidth;
+    const windowHeight = window.innerHeight;
+    
+    // Center the tooltip horizontally under the cursor (accounting for scroll)
+    let left = mouseX - (tooltipRect.width / 2);
+    let top = mouseY + offset;
+    
+    // Adjust horizontal position if tooltip would go off screen
+    // Keep it as close to centered as possible while staying on screen
+    if (left < 5) {
+        left = 5;
+    } else if (left + tooltipRect.width > windowWidth - 5) {
+        left = windowWidth - tooltipRect.width - 5;
+    }
+    
+    // Adjust vertical position if tooltip would go off screen
+    if (top + tooltipRect.height > windowHeight - 5) {
+        top = mouseY - tooltipRect.height - offset;
+    }
+    
+    // Ensure tooltip doesn't go off the top edge
+    top = Math.max(5, top);
+    
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+}
+
+function hideTooltip() {
+    const tooltip = document.getElementById('joker-tooltip');
+    tooltip.classList.remove('show');
+}
+
+function updateTooltipPosition(event) {
+    const tooltip = document.getElementById('joker-tooltip');
+    const mouseX = event.clientX;
+    const mouseY = event.clientY;
+    const offset = 15;
+    
+    // Get tooltip dimensions
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const windowWidth = window.innerWidth;
+    const windowHeight = window.innerHeight;
+    
+    // Center the tooltip horizontally under the cursor (accounting for scroll)
+    let left = mouseX - (tooltipRect.width / 2);
+    let top = mouseY + offset;
+    
+    // Adjust horizontal position if tooltip would go off screen
+    // Keep it as close to centered as possible while staying on screen
+    if (left < 5) {
+        left = 5;
+    } else if (left + tooltipRect.width > windowWidth - 5) {
+        left = windowWidth - tooltipRect.width - 5;
+    }
+    
+    // Adjust vertical position if tooltip would go off screen
+    if (top + tooltipRect.height > windowHeight - 5) {
+        top = mouseY - tooltipRect.height - offset;
+    }
+    
+    // Ensure tooltip doesn't go off the top edge
+    top = Math.max(5, top);
+    
+    // Apply positioning with scroll offset
+    tooltip.style.left = left + 'px';
+    tooltip.style.top = top + 'px';
+    tooltip.style.position = 'fixed'; // Use fixed positioning relative to viewport
 }

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -74,6 +74,7 @@ function initPage() {
         totalJokers = data.length;
         // console.log('Success:', data);
         generateJokerGrid(data);
+        setupTooltipEvents(); // Set up tooltip event listeners
     })
     .catch((error) => {
         console.error('Error:', error);
@@ -323,7 +324,7 @@ function setupTooltipEvents() {
             }
             // If tooltip is already showing, update its position
             if (tooltip.classList.contains('show')) {
-                updateTooltipPosition(e);
+                updateTooltipPosition(e.clientX, e.clientY);
             }
         } else {
             clearTooltipTimer();
@@ -384,41 +385,8 @@ function showTooltip(card) {
     tooltip.querySelector('.tooltip-description').innerHTML = jokerData.description;
     
     // Position and show tooltip using stored mouse position
-    updateTooltipPositionFromCoords(currentMousePosition.x, currentMousePosition.y);
+    updateTooltipPosition(currentMousePosition.x, currentMousePosition.y);
     tooltip.classList.add('show');
-}
-
-function updateTooltipPositionFromCoords(mouseX, mouseY) {
-    const tooltip = document.getElementById('joker-tooltip');
-    const offset = 15;
-    
-    // Get tooltip dimensions
-    const tooltipRect = tooltip.getBoundingClientRect();
-    const windowWidth = window.innerWidth;
-    const windowHeight = window.innerHeight;
-    
-    // Center the tooltip horizontally under the cursor (accounting for scroll)
-    let left = mouseX - (tooltipRect.width / 2);
-    let top = mouseY + offset;
-    
-    // Adjust horizontal position if tooltip would go off screen
-    // Keep it as close to centered as possible while staying on screen
-    if (left < 5) {
-        left = 5;
-    } else if (left + tooltipRect.width > windowWidth - 5) {
-        left = windowWidth - tooltipRect.width - 5;
-    }
-    
-    // Adjust vertical position if tooltip would go off screen
-    if (top + tooltipRect.height > windowHeight - 5) {
-        top = mouseY - tooltipRect.height - offset;
-    }
-    
-    // Ensure tooltip doesn't go off the top edge
-    top = Math.max(5, top);
-    
-    tooltip.style.left = `${left}px`;
-    tooltip.style.top = `${top}px`;
 }
 
 function hideTooltip() {
@@ -426,10 +394,8 @@ function hideTooltip() {
     tooltip.classList.remove('show');
 }
 
-function updateTooltipPosition(event) {
+function updateTooltipPosition(mouseX, mouseY) {
     const tooltip = document.getElementById('joker-tooltip');
-    const mouseX = event.clientX;
-    const mouseY = event.clientY;
     const offset = 15;
     
     // Get tooltip dimensions
@@ -457,8 +423,8 @@ function updateTooltipPosition(event) {
     // Ensure tooltip doesn't go off the top edge
     top = Math.max(5, top);
     
-    // Apply positioning with scroll offset
-    tooltip.style.left = left + 'px';
-    tooltip.style.top = top + 'px';
-    tooltip.style.position = 'fixed'; // Use fixed positioning relative to viewport
+    // Apply positioning with fixed positioning relative to viewport
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+    tooltip.style.position = 'fixed';
 }

--- a/static/style.css
+++ b/static/style.css
@@ -194,7 +194,7 @@ input[type="checkbox"]:checked + .custom-checkbox::before {
 .joker-tooltip {
     position: absolute;
     z-index: 1000;
-    background-color: #666666;
+    background-color: rgb(52, 62, 63);
     border: 2px solid #333333;
     border-radius: 8px;
     padding: 8px;
@@ -211,11 +211,40 @@ input[type="checkbox"]:checked + .custom-checkbox::before {
 
 .tooltip-title {
     color: white;
-    font-size: 16px;
-    font-weight: bold;
+    font-size: 24px;
     margin-bottom: 6px;
     text-shadow: 0.1rem 0.1rem 0px #000000;
     text-align: center;
+}
+
+.tooltip-rarity {
+    color: white;
+    font-size: 14px;
+    font-weight: bold;
+    margin-top: 6px;
+    text-align: center;
+    padding: 4px 12px;
+    border-radius: 6px;
+    text-shadow: 0.1rem 0.1rem 0px #000000;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    border: 2px solid rgba(255,255,255,0.3);
+}
+
+.tooltip-rarity.rarity-1 {
+    background-color: #009dff; /* Common - Blue */
+}
+
+.tooltip-rarity.rarity-2 {
+    background-color: #4BC292; /* Uncommon - Green */
+}
+
+.tooltip-rarity.rarity-3 {
+    background-color: #fe5f55; /* Rare - Red */
+}
+
+.tooltip-rarity.rarity-4 {
+    background-color: #b26cbb; /* Legendary - Purple */
 }
 
 .tooltip-description {
@@ -227,6 +256,11 @@ input[type="checkbox"]:checked + .custom-checkbox::before {
     line-height: 1.3;
     text-shadow: none;
     text-align: center;
+    min-width: 200px;
+    min-height: 50px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 /* Balatro Joker Description Styles - Tooltip specific only */

--- a/static/style.css
+++ b/static/style.css
@@ -189,3 +189,101 @@ input[type="checkbox"]:checked + .custom-checkbox::before {
 .card-body {
     padding: 0;
 }
+
+/* Joker Tooltip Styles */
+.joker-tooltip {
+    position: absolute;
+    z-index: 1000;
+    background-color: #666666;
+    border: 2px solid #333333;
+    border-radius: 8px;
+    padding: 8px;
+    max-width: 300px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+
+.joker-tooltip.show {
+    opacity: 1;
+}
+
+.tooltip-title {
+    color: white;
+    font-size: 16px;
+    font-weight: bold;
+    margin-bottom: 6px;
+    text-shadow: 0.1rem 0.1rem 0px #000000;
+    text-align: center;
+}
+
+.tooltip-description {
+    background-color: white;
+    color: black;
+    padding: 8px;
+    border-radius: 6px;
+    font-size: 14px;
+    line-height: 1.3;
+    text-shadow: none;
+    text-align: center;
+}
+
+/* Balatro Joker Description Styles - Tooltip specific only */
+
+/* Base color classes */
+.c-red { color: #FE5F55; }
+.c-blue { color: #009DFF; }
+.c-green { color: #4BC292; }
+.c-purple { color: #8867A5; }
+.c-orange { color: #FDA200; }
+.c-yellow { color: #ffd43b; }
+.c-white { color: #ffffff; }
+.c-black { color: #000000; }
+.c-grey { color: #868e96; }
+.c-gray { color: #868e96; }
+.c-gold { color: #EAC058; }
+
+/* Semantic color classes */
+.c-money { color: #F3B958; }
+.c-chips { color: #009DFF; }
+.c-mult { color: #FE5F55; }
+.c-attention { color: #FF9A00; }
+.c-inactive { color: #888888AA; }
+.c-dark-edition { color: #000000; }
+.c-legendary { color: #B26CBB; }
+.c-spectral { color: #4584FA; }
+.c-voucher { color: #CB724C; }
+.c-enhancement { color: #8389DD; }
+.c-joker { color: #ffd43b; }
+.c-tarot { color: #A782D1; }
+.c-planet { color: #13AFCE; }
+.c-playing-card { color: #ffffff; }
+.c-important { color: #ff6b6b; }
+.c-edition { color: #FFFFFF; }
+
+/* Additional UI colors */
+.c-booster { color: #646EB7; }
+.c-eternal { color: #C75985; }
+.c-perishable { color: #4F5DA1; }
+.c-rental { color: #B18F43; }
+.c-joker-grey { color: #BFC7D5; }
+.c-pale-green { color: #56A887; }
+
+/* Suit colors */
+.c-hearts { color: #FE5F55; }
+.c-diamonds { color: #FE5F55; }
+.c-clubs { color: #424E54; }
+.c-spades { color: #374649; }
+
+/* Special formatting classes */
+.x-mult {
+    font-weight: bold;
+    font-size: 1.1em;
+    color: #ff6b6b;
+}
+
+.variable {
+    color: #4f90ec;
+    font-weight: bold;
+}


### PR DESCRIPTION
Basically I love the C++ tracker but I found myself consistently wishing there were tooltips for the jokers I wasn't sure of what they did. I attempted to parse the descriptions out of the game files (not aware of anywhere these are available), which I honestly regret even getting involved with. But if you're interested in merging it, here they are.

I see you have put in the README that you plan for other localization support, however that was over a year ago so I'm guessing those plans are abandoned. If you ever decided to add it, I could potentially rip the descriptions in other languages as well with the workflow I have set up (which is honestly a mess)

### Behaviour:
* The jokers.json now includes a field for description which includes html tags for css classes.
* Include card rarity on tooltip, aiming to look as similar as possible to game description.
* Game-accurate coloring
* Game accurate text-to-line-number descriptions
* Some hints re jokers like "The Idol" - random _owned_ suit/rank vs "Ancient Joker" which is a random suit (doesn't care if you own it)
* On hover, a tooltip will display after 500ms. The code would be much simpler overall without the timer code, but it is a bit annoying having a tooltip visible basically 100% of the time.
* On scroll, hide the tooltip. Otherwise it's a bit annoying.

<img width="323" height="278" alt="image" src="https://github.com/user-attachments/assets/6382dc32-00dc-437f-95a6-99aa2996b0f4" />
<img width="328" height="290" alt="image" src="https://github.com/user-attachments/assets/adeb09da-365b-4045-88b6-e1f385065ae0" />
<img width="313" height="272" alt="image" src="https://github.com/user-attachments/assets/ea10f33a-dbf3-4902-be08-c7759c5c1e8f" />
<img width="317" height="265" alt="image" src="https://github.com/user-attachments/assets/f5182110-c932-4f51-a2e3-879484f57f5a" />
